### PR TITLE
GIN & GORM logging integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   libraries. Heavily inspired by [rs/zerolog](https://github.com/rs/zerolog).
   (#10, #13, #15, #20)
 
+- Added `pkg/logger` integration to Gin-Gonic and GORM inside `pkg/ginutil` and
+  `pkg/gormutil`. (#11)
+
 - Added new error response functions. (#17)
 
 - Added `pkg/env` to bind environment variable of a range of different types to

--- a/pkg/ginutil/logger.go
+++ b/pkg/ginutil/logger.go
@@ -1,0 +1,138 @@
+package ginutil
+
+import (
+	"errors"
+	"io"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/iver-wharf/wharf-core/pkg/logger"
+)
+
+// LoggerConfig holds configuration for the Gin logging integration.
+type LoggerConfig struct {
+	// Level is the logging level that each log message uses. Defaults to the
+	// zero value of logger.Level, which is logger.LevelDebug.
+	Level logger.Level
+	// Logger is the logger implementation used when logging.
+	Logger logger.Logger
+	// OmitClientIP leaves out the client IP address that issued the web request
+	// from the logs when set to true.
+	OmitClientIP bool
+	// OmitLatency leaves out the server cost in time for processing a request
+	// from the logs when set to true.
+	OmitLatency bool
+	// OmitMethod leaves out the HTTP method (GET, POST, DELETE, HEAD, etc.)
+	// that was used in the web request from the logs when set to true.
+	OmitMethod bool
+	// OmitPath leaves out the web request path (the URL without the protocol,
+	// hostname, query parameters, and such) from the logs when set to true.
+	OmitPath bool
+	// OmitStatus leaves out the HTTP status (200 OK, 404 Not Found, etc.) of
+	// the web response from the logs when set to true.
+	OmitStatus bool
+	// OmitError leaves out any Go errors that were thrown when processing the
+	// web request from the logs when set to true.
+	OmitError bool
+	// SkipPaths is a url path array which logs are not written. Useful for
+	// disabling logs issued by health checks.
+	SkipPaths []string
+}
+
+// DefaultLoggerHandler is a Gin-compatible logger that uses wharf-core logging.
+var DefaultLoggerHandler = LoggerWithConfig(LoggerConfig{
+	Level: logger.LevelDebug,
+})
+
+// LoggerWithConfig creates a Gin middleware handler function that logs all
+// requests using the logging level from the config.
+//
+// If the logger implementation inside the config is unset, then it defaults to
+// a new scoped logger with the scope "GIN".
+func LoggerWithConfig(config LoggerConfig) gin.HandlerFunc {
+	if config.Logger == nil {
+		config.Logger = logger.NewScoped("GIN")
+	}
+	return gin.LoggerWithConfig(gin.LoggerConfig{
+		SkipPaths: config.SkipPaths,
+		Formatter: func(param gin.LogFormatterParams) string {
+			ev := logger.NewEventFromLogger(config.Logger, config.Level)
+			if !config.OmitClientIP {
+				ev = ev.WithString("clientIp", param.ClientIP)
+			}
+			if !config.OmitMethod {
+				ev = ev.WithString("method", param.Method)
+			}
+			if !config.OmitPath {
+				ev = ev.WithString("path", param.Path)
+			}
+			if !config.OmitStatus {
+				ev = ev.WithInt("status", param.StatusCode)
+			}
+			if !config.OmitLatency {
+				ev = ev.WithDuration("latency", param.Latency)
+			}
+			if param.ErrorMessage != "" && !config.OmitError {
+				ev = ev.WithError(errors.New(param.ErrorMessage))
+			}
+			ev.Message("")
+			return ""
+		},
+		// if writer is not set then it defaults to os.Stdout
+		Output: nopWriter{},
+	})
+}
+
+type nopWriter struct{}
+
+func (w nopWriter) Write(b []byte) (int, error) {
+	return len(b), nil
+}
+
+// DefaultLoggerWriter is an io.Writer that logs all written messages using
+// appropriate logging levels on a logger with the scope "GIN-debug".
+//
+// Any [GIN-debug] messages are trimmed away.
+//
+// Any messages starting with [WARNING] or [ERROR] are logged with the
+// appropriate logging levels, and any other logs will use debug logging.
+var DefaultLoggerWriter = NewLoggerWriter(logger.NewScoped("GIN-debug"), logger.LevelDebug)
+
+type loggerWriter struct {
+	logger       logger.Logger
+	defaultLevel logger.Level
+}
+
+// NewLoggerWriter creates a logger that channels everything written to it via a
+// wharf-core logger.
+//
+// Any [GIN-debug] messages are trimmed away.
+//
+// Any messages starting with [WARNING] or [ERROR] are logged with the
+// appropriate logging levels, and any other logs will use the default logging
+// level provided to this function.
+func NewLoggerWriter(log logger.Logger, defaultLevel logger.Level) io.Writer {
+	return loggerWriter{log, defaultLevel}
+}
+
+func (w loggerWriter) Write(p []byte) (n int, err error) {
+	const (
+		prefixGinDebug = "[GIN-debug] "
+		prefixWarning  = "[WARNING] "
+		prefixError    = "[ERROR] "
+	)
+
+	var message = strings.TrimPrefix(strings.TrimRight(string(p), "\n"), prefixGinDebug)
+	var level = w.defaultLevel
+
+	if strings.HasPrefix(message, prefixWarning) {
+		message = strings.TrimPrefix(message, prefixWarning)
+		level = logger.LevelWarn
+	} else if strings.HasPrefix(message, prefixError) {
+		message = strings.TrimPrefix(message, prefixError)
+		level = logger.LevelError
+	}
+
+	logger.NewEventFromLogger(w.logger, level).Message(message)
+	return len(p), nil
+}

--- a/pkg/ginutil/logger_example_test.go
+++ b/pkg/ginutil/logger_example_test.go
@@ -14,41 +14,14 @@ func init() {
 	gin.SetMode(gin.ReleaseMode)
 }
 
-func ExampleLoggerWithConfig() {
-	r := gin.New()
-
-	r.Use(ginutil.LoggerWithConfig(ginutil.LoggerConfig{
-		Logger:      logger.NewScoped("gin"),
-		OmitLatency: true, // untestable
-	}))
-
-	// Don't forget to set up your outputs!
-	conf := consolepretty.Config{
-		DisableDate:       true,
-		DisableCallerLine: true,
-	}
-	defer logger.ClearOutputs()
-	logger.AddOutput(logger.LevelDebug, consolepretty.New(conf))
-
-	// Faking a request here
-	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/ping", nil)
-	r.ServeHTTP(w, req)
-
-	// Output:
-	// [DEBUG | gin | gin@v1.7.1/logger.go] clientIp=``  method=GET  path=/ping  status=404
-}
-
 func ExampleDefaultLoggerHandler() {
+	logger.AddOutput(logger.LevelDebug, consolepretty.Default)
+
 	r := gin.New()
 
 	r.Use(ginutil.DefaultLoggerHandler)
 	gin.DefaultWriter = ginutil.DefaultLoggerWriter
 	gin.DefaultErrorWriter = ginutil.DefaultLoggerWriter
-
-	// Don't forget to set up your outputs!
-	defer logger.ClearOutputs()
-	logger.AddOutput(logger.LevelDebug, consolepretty.Default)
 
 	// Faking a request here
 	w := httptest.NewRecorder()

--- a/pkg/ginutil/logger_example_test.go
+++ b/pkg/ginutil/logger_example_test.go
@@ -1,0 +1,57 @@
+package ginutil_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/gin-gonic/gin"
+	"github.com/iver-wharf/wharf-core/pkg/ginutil"
+	"github.com/iver-wharf/wharf-core/pkg/logger"
+	"github.com/iver-wharf/wharf-core/pkg/logger/consolepretty"
+)
+
+func init() {
+	gin.SetMode(gin.ReleaseMode)
+}
+
+func ExampleLoggerWithConfig() {
+	r := gin.New()
+
+	r.Use(ginutil.LoggerWithConfig(ginutil.LoggerConfig{
+		Logger:      logger.NewScoped("gin"),
+		OmitLatency: true, // untestable
+	}))
+
+	// Don't forget to set up your outputs!
+	conf := consolepretty.Config{
+		DisableDate:       true,
+		DisableCallerLine: true,
+	}
+	defer logger.ClearOutputs()
+	logger.AddOutput(logger.LevelDebug, consolepretty.New(conf))
+
+	// Faking a request here
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/ping", nil)
+	r.ServeHTTP(w, req)
+
+	// Output:
+	// [DEBUG | gin | gin@v1.7.1/logger.go] clientIp=``  method=GET  path=/ping  status=404
+}
+
+func ExampleDefaultLoggerHandler() {
+	r := gin.New()
+
+	r.Use(ginutil.DefaultLoggerHandler)
+	gin.DefaultWriter = ginutil.DefaultLoggerWriter
+	gin.DefaultErrorWriter = ginutil.DefaultLoggerWriter
+
+	// Don't forget to set up your outputs!
+	defer logger.ClearOutputs()
+	logger.AddOutput(logger.LevelDebug, consolepretty.Default)
+
+	// Faking a request here
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/ping", nil)
+	r.ServeHTTP(w, req)
+}

--- a/pkg/gormutil/logger.go
+++ b/pkg/gormutil/logger.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/iver-wharf/wharf-core/internal/traceutil"
 	"github.com/iver-wharf/wharf-core/pkg/logger"
 	"gorm.io/gorm"
 	gormlogger "gorm.io/gorm/logger"
@@ -30,7 +29,7 @@ type LoggerConfig struct {
 	// SlowThreshold sets what duration is considered a slow SQL operation.
 	// If an operation takes longer than this to complete then a warning log
 	// message will be emitted.
-	// 
+	//
 	// Set to 0 to disable.
 	SlowThreshold time.Duration
 }
@@ -88,8 +87,7 @@ func (log gormLog) Trace(_ context.Context, begin time.Time, fc func() (sql stri
 	switch {
 	case log.shouldLogError(err):
 		sql, rowsAffected := fc()
-		ev := log.Logger.Error().
-			WithCaller(traceutil.CallerFileWithLineNum())
+		ev := log.Logger.Error()
 		ev = withRowsAffected(ev, rowsAffected)
 		ev.WithDuration("elapsed", elapsed).
 			WithError(err).
@@ -97,8 +95,7 @@ func (log gormLog) Trace(_ context.Context, begin time.Time, fc func() (sql stri
 			Message("Error in SQL.")
 	case log.shouldLogWarnSlow(elapsed):
 		sql, rowsAffected := fc()
-		ev := log.Logger.Warn().
-			WithCaller(traceutil.CallerFileWithLineNum())
+		ev := log.Logger.Warn()
 		ev = withRowsAffected(ev, rowsAffected)
 		ev.WithDuration("elapsed", elapsed).
 			WithDuration("threshold", log.SlowThreshold).
@@ -106,8 +103,7 @@ func (log gormLog) Trace(_ context.Context, begin time.Time, fc func() (sql stri
 			Message("Slow SQL.")
 	case log.shouldLogDebug():
 		sql, rowsAffected := fc()
-		ev := log.Logger.Debug().
-			WithCaller(traceutil.CallerFileWithLineNum())
+		ev := log.Logger.Debug()
 		ev = withRowsAffected(ev, rowsAffected)
 		ev.WithDuration("elapsed", elapsed).
 			WithString("sql", sql).

--- a/pkg/gormutil/logger.go
+++ b/pkg/gormutil/logger.go
@@ -1,0 +1,140 @@
+package gormutil
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/iver-wharf/wharf-core/internal/traceutil"
+	"github.com/iver-wharf/wharf-core/pkg/logger"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+// LoggerConfig holds configuration for the GORM logging integration. Many
+// configuration values of in the gorm.io/gorm/logger.Config will you also find
+// in here.
+type LoggerConfig struct {
+	// Logger is the logger implementation used when logging. This defaults to
+	// a new scoped logger with the scope "GORM".
+	Logger logger.Logger
+	// AlsoUseGORMLogLevel sets wether to honor GORM's own logging levels.
+	//
+	// If set to false (which is the default) then the logging level
+	// configuration from the wharf-core logging library will be the only one
+	// filtering logs.
+	AlsoUseGORMLogLevel bool
+	// IgnoreRecordNotFoundError will omit any "RecordNotFound" errors if set
+	// to true.
+	IgnoreRecordNotFoundError bool
+	// SlowThreshold sets what duration is considered a slow SQL operation.
+	// If an operation takes longer than this to complete then a warning log
+	// message will be emitted.
+	// 
+	// Set to 0 to disable.
+	SlowThreshold time.Duration
+}
+
+type gormLog struct {
+	LoggerConfig
+	level gormlogger.LogLevel
+}
+
+// DefaultLogger is a GORM-compatible logger that uses wharf-core logging.
+var DefaultLogger = NewLogger(LoggerConfig{
+	IgnoreRecordNotFoundError: true,
+	SlowThreshold:             200 * time.Millisecond,
+})
+
+// NewLogger creates a new gorm.io/gorm/logger.Interface compatible logger.
+func NewLogger(config LoggerConfig) gormlogger.Interface {
+	if config.Logger == nil {
+		config.Logger = logger.NewScoped("GORM")
+	}
+	return gormLog{
+		LoggerConfig: config,
+		level:        gormlogger.Info,
+	}
+}
+
+func (log gormLog) LogMode(level gormlogger.LogLevel) gormlogger.Interface {
+	log.level = level
+	return log
+}
+
+func (log gormLog) Info(_ context.Context, message string, args ...interface{}) {
+	if log.level >= gormlogger.Info || !log.AlsoUseGORMLogLevel {
+		log.Logger.Info().Messagef(message, args...)
+	}
+}
+
+func (log gormLog) Warn(_ context.Context, message string, args ...interface{}) {
+	if log.level >= gormlogger.Warn || !log.AlsoUseGORMLogLevel {
+		log.Logger.Warn().Messagef(message, args...)
+	}
+}
+
+func (log gormLog) Error(_ context.Context, message string, args ...interface{}) {
+	if log.level >= gormlogger.Error || !log.AlsoUseGORMLogLevel {
+		log.Logger.Error().Messagef(message, args...)
+	}
+}
+
+func (log gormLog) Trace(_ context.Context, begin time.Time, fc func() (sql string, rowsAffected int64), err error) {
+	if log.level <= gormlogger.Silent && log.AlsoUseGORMLogLevel {
+		return
+	}
+	elapsed := time.Since(begin)
+	switch {
+	case log.shouldLogError(err):
+		sql, rowsAffected := fc()
+		ev := log.Logger.Error().
+			WithCaller(traceutil.CallerFileWithLineNum())
+		ev = withRowsAffected(ev, rowsAffected)
+		ev.WithDuration("elapsed", elapsed).
+			WithError(err).
+			WithString("sql", sql).
+			Message("Error in SQL.")
+	case log.shouldLogWarnSlow(elapsed):
+		sql, rowsAffected := fc()
+		ev := log.Logger.Warn().
+			WithCaller(traceutil.CallerFileWithLineNum())
+		ev = withRowsAffected(ev, rowsAffected)
+		ev.WithDuration("elapsed", elapsed).
+			WithDuration("threshold", log.SlowThreshold).
+			WithString("sql", sql).
+			Message("Slow SQL.")
+	case log.shouldLogDebug():
+		sql, rowsAffected := fc()
+		ev := log.Logger.Debug().
+			WithCaller(traceutil.CallerFileWithLineNum())
+		ev = withRowsAffected(ev, rowsAffected)
+		ev.WithDuration("elapsed", elapsed).
+			WithString("sql", sql).
+			Message("")
+	}
+}
+
+func withRowsAffected(ev logger.Event, rows int64) logger.Event {
+	if rows == -1 {
+		return ev.WithRune("rows", '-')
+	}
+	return ev.WithInt64("rows", rows)
+}
+
+func (log gormLog) shouldLogError(err error) bool {
+	return err != nil &&
+		(log.level >= gormlogger.Error || !log.AlsoUseGORMLogLevel) &&
+		(!errors.Is(err, gorm.ErrRecordNotFound) ||
+			!log.IgnoreRecordNotFoundError)
+}
+
+func (log gormLog) shouldLogWarnSlow(elapsed time.Duration) bool {
+	return elapsed > log.SlowThreshold &&
+		log.SlowThreshold != 0 &&
+		(log.level >= gormlogger.Warn || !log.AlsoUseGORMLogLevel)
+}
+
+func (log gormLog) shouldLogDebug() bool {
+	return log.level == gormlogger.Info || !log.AlsoUseGORMLogLevel
+}

--- a/pkg/gormutil/logger_example_test.go
+++ b/pkg/gormutil/logger_example_test.go
@@ -1,0 +1,42 @@
+package gormutil_test
+
+import (
+	"fmt"
+
+	"github.com/iver-wharf/wharf-core/pkg/gormutil"
+	"github.com/iver-wharf/wharf-core/pkg/logger"
+	"github.com/iver-wharf/wharf-core/pkg/logger/consolepretty"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func ExampleNewLogger() {
+	defer logger.ClearOutputs()
+	logger.AddOutput(logger.LevelDebug, consolepretty.New(consolepretty.Config{
+		DisableDate:       true,
+		DisableCallerLine: true,
+	}))
+
+	db, err := gorm.Open(postgres.Open("host=localhost"), &gorm.Config{
+		DryRun:               true,
+		DisableAutomaticPing: true,
+		Logger: gormutil.NewLogger(gormutil.LoggerConfig{
+			Logger: logger.NewScoped("GORM"),
+		}),
+	})
+
+	if err != nil {
+		fmt.Println("Error connecting to database:", err)
+		return
+	}
+
+	type User struct {
+		ID   int
+		Name string `gorm:"size:256"`
+	}
+
+	db.Find(&User{}, 1)
+
+	// Sample output:
+	// [DEBUG | GORM | gorm@v1.21.10/callbacks.go] rows=0  elapsed=89.768µs  sql=`SELECT * FROM "users" WHERE "users"."id" = 1`
+}

--- a/pkg/gormutil/logger_example_test.go
+++ b/pkg/gormutil/logger_example_test.go
@@ -10,19 +10,13 @@ import (
 	"gorm.io/gorm"
 )
 
-func ExampleNewLogger() {
-	defer logger.ClearOutputs()
-	logger.AddOutput(logger.LevelDebug, consolepretty.New(consolepretty.Config{
-		DisableDate:       true,
-		DisableCallerLine: true,
-	}))
+func ExampleDefaultLogger() {
+	logger.AddOutput(logger.LevelDebug, consolepretty.Default)
 
 	db, err := gorm.Open(postgres.Open("host=localhost"), &gorm.Config{
 		DryRun:               true,
 		DisableAutomaticPing: true,
-		Logger: gormutil.NewLogger(gormutil.LoggerConfig{
-			Logger: logger.NewScoped("GORM"),
-		}),
+		Logger:               gormutil.DefaultLogger,
 	})
 
 	if err != nil {
@@ -34,9 +28,5 @@ func ExampleNewLogger() {
 		ID   int
 		Name string `gorm:"size:256"`
 	}
-
 	db.Find(&User{}, 1)
-
-	// Sample output:
-	// [DEBUG | GORM | gorm@v1.21.10/callbacks.go] rows=0  elapsed=89.768µs  sql=`SELECT * FROM "users" WHERE "users"."id" = 1`
 }

--- a/pkg/gormutil/logger_test.go
+++ b/pkg/gormutil/logger_test.go
@@ -1,0 +1,241 @@
+package gormutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/iver-wharf/wharf-core/pkg/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+var (
+	logInfoFunc = func(ctx context.Context, logger gormlogger.Interface, message string) {
+		logger.Info(ctx, message)
+	}
+	logWarnFunc = func(ctx context.Context, logger gormlogger.Interface, message string) {
+		logger.Warn(ctx, message)
+	}
+	logErrorFunc = func(ctx context.Context, logger gormlogger.Interface, message string) {
+		logger.Error(ctx, message)
+	}
+)
+
+func TestLoggerSilencedByWrongGORMLogLevel(t *testing.T) {
+	testCases := []struct {
+		name      string
+		logLevels []gormlogger.LogLevel
+		logFunc   func(context.Context, gormlogger.Interface, string)
+	}{
+		{
+			name:      "info",
+			logLevels: []gormlogger.LogLevel{gormlogger.Silent, gormlogger.Warn, gormlogger.Error},
+			logFunc:   logInfoFunc,
+		},
+		{
+			name:      "warn",
+			logLevels: []gormlogger.LogLevel{gormlogger.Silent, gormlogger.Error},
+			logFunc:   logWarnFunc,
+		},
+		{
+			name:      "error",
+			logLevels: []gormlogger.LogLevel{gormlogger.Silent},
+			logFunc:   logErrorFunc,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			logMock := logger.NewMock()
+			for _, logLevel := range tc.logLevels {
+				t.Run(logLevelStr(logLevel), func(t *testing.T) {
+					log := NewLogger(LoggerConfig{
+						Logger:              logMock,
+						AlsoUseGORMLogLevel: true,
+					}).LogMode(logLevel)
+
+					tc.logFunc(context.Background(), log, "some message")
+
+					assert.Empty(t, logMock.Logs)
+				})
+			}
+		})
+	}
+}
+
+func TestLoggerUsingGORMLogLevel(t *testing.T) {
+	testCases := []struct {
+		name         string
+		logLevels    []gormlogger.LogLevel
+		wantLogLevel logger.Level
+		logFunc      func(context.Context, gormlogger.Interface, string)
+	}{
+		{
+			name:         "info",
+			logLevels:    []gormlogger.LogLevel{gormlogger.Info},
+			wantLogLevel: logger.LevelInfo,
+			logFunc:      logInfoFunc,
+		},
+		{
+			name:         "warn",
+			logLevels:    []gormlogger.LogLevel{gormlogger.Warn, gormlogger.Info},
+			wantLogLevel: logger.LevelWarn,
+			logFunc:      logWarnFunc,
+		},
+		{
+			name:         "error",
+			logLevels:    []gormlogger.LogLevel{gormlogger.Error, gormlogger.Warn, gormlogger.Info},
+			wantLogLevel: logger.LevelError,
+			logFunc:      logErrorFunc,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			logMock := logger.NewMock()
+			for _, logLevel := range tc.logLevels {
+				t.Run(logLevelStr(logLevel), func(t *testing.T) {
+					log := NewLogger(LoggerConfig{
+						Logger:              logMock,
+						AlsoUseGORMLogLevel: true,
+					}).LogMode(logLevel)
+
+					tc.logFunc(context.Background(), log, "some message")
+
+					require.NotEmpty(t, logMock.Logs)
+
+					assert.Equal(t, tc.wantLogLevel, logMock.Logs[0].Level, "logged level")
+					assert.Equal(t, "some message", logMock.Logs[0].Message)
+				})
+			}
+		})
+	}
+}
+
+func TestLoggerTraceLogsFields(t *testing.T) {
+	var (
+		baseFields = []string{"caller", "line", "rows", "sql", "elapsed"}
+
+		testCases = []struct {
+			name           string
+			logLevel       gormlogger.LogLevel
+			begin          time.Time
+			err            error
+			wantFieldNames []string
+			wantLogLevel   logger.Level
+		}{
+			{
+				name:           "non-'record not found' error",
+				logLevel:       gormlogger.Error,
+				begin:          time.Now(),
+				err:            errors.New("this is not a 'record not found' error"),
+				wantFieldNames: append(baseFields, "error"),
+				wantLogLevel:   logger.LevelError,
+			},
+			{
+				name:           "slow SQL warn",
+				logLevel:       gormlogger.Warn,
+				begin:          time.Now().Add(-time.Minute),
+				err:            nil,
+				wantFieldNames: append(baseFields, "threshold"),
+				wantLogLevel:   logger.LevelWarn,
+			},
+			{
+				name:           "SQL debug",
+				logLevel:       gormlogger.Info,
+				begin:          time.Now(),
+				err:            nil,
+				wantFieldNames: baseFields,
+				wantLogLevel:   logger.LevelDebug,
+			},
+		}
+
+		fakeSQL            = "SELECT * FROM null"
+		affectedRows int64 = 42
+
+		fc = func() (string, int64) {
+			return fakeSQL, affectedRows
+		}
+	)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			logMock := logger.NewMock()
+			log := NewLogger(LoggerConfig{
+				Logger:              logMock,
+				AlsoUseGORMLogLevel: true,
+				SlowThreshold:       time.Millisecond * 200,
+			}).LogMode(tc.logLevel)
+
+			log.Trace(context.Background(), tc.begin, fc, tc.err)
+
+			require.NotEmpty(t, logMock.Logs)
+			assert.Equal(t, tc.wantLogLevel, logMock.Logs[0].Level, "logged level")
+			assert.ElementsMatch(t, tc.wantFieldNames, logMock.Logs[0].FieldNames, "logged field names")
+			assert.Equal(t, fakeSQL, logMock.Logs[0].Fields["sql"], "logged 'sql' field")
+			assert.Equal(t, affectedRows, logMock.Logs[0].Fields["rows"], "logged 'rows' field")
+		})
+	}
+}
+
+func TestLoggerTraceNoLogsWhenSilenced(t *testing.T) {
+	var (
+		logLevel = gormlogger.Silent
+		err      = errors.New("should not be logged")
+		fc       = func() (string, int64) {
+			return "SELECT * FROM null", 42
+		}
+		logMock = logger.NewMock()
+		log     = NewLogger(LoggerConfig{
+			Logger:              logMock,
+			AlsoUseGORMLogLevel: true,
+		}).LogMode(logLevel)
+	)
+	log.Trace(context.Background(), time.Now(), fc, err)
+	assert.Empty(t, logMock.Logs)
+}
+
+func TestLoggerOutput(t *testing.T) {
+	var (
+		wantFieldNames = []string{"caller", "line", "rows", "elapsed", "sql"}
+		log            = logger.NewMock()
+		db, err        = gorm.Open(postgres.Open("host=localhost"), &gorm.Config{
+			DryRun:               true,
+			DisableAutomaticPing: true,
+			Logger: NewLogger(LoggerConfig{
+				Logger: log,
+			}),
+		})
+	)
+
+	require.Nil(t, err)
+
+	type User struct {
+		gorm.Model
+		Name string `gorm:"size:256"`
+	}
+
+	db.Find(&User{}, 1)
+
+	require.NotEmpty(t, log.Logs, "logged messages")
+	assert.Equal(t, 1, len(log.Logs), "logged message count")
+	assert.ElementsMatch(t, wantFieldNames, log.Logs[0].FieldNames)
+}
+
+func logLevelStr(lvl gormlogger.LogLevel) string {
+	switch lvl {
+	case gormlogger.Silent:
+		return "Silent"
+	case gormlogger.Info:
+		return "Info"
+	case gormlogger.Warn:
+		return "Warn"
+	case gormlogger.Error:
+		return "Error"
+	default:
+		return fmt.Sprintf("LogLevel(%d)", int(lvl))
+	}
+}

--- a/pkg/gormutil/logger_test.go
+++ b/pkg/gormutil/logger_test.go
@@ -174,7 +174,7 @@ func TestLoggerTraceLogsFields(t *testing.T) {
 
 			require.NotEmpty(t, logMock.Logs)
 			assert.Equal(t, tc.wantLogLevel, logMock.Logs[0].Level, "logged level")
-			assert.ElementsMatch(t, tc.wantFieldNames, logMock.Logs[0].FieldNames, "logged field names")
+			assert.ElementsMatch(t, tc.wantFieldNames, logMock.Logs[0].FieldsAdded, "logged field names")
 			assert.Equal(t, fakeSQL, logMock.Logs[0].Fields["sql"], "logged 'sql' field")
 			assert.Equal(t, affectedRows, logMock.Logs[0].Fields["rows"], "logged 'rows' field")
 		})
@@ -222,7 +222,7 @@ func TestLoggerOutput(t *testing.T) {
 
 	require.NotEmpty(t, log.Logs, "logged messages")
 	assert.Equal(t, 1, len(log.Logs), "logged message count")
-	assert.ElementsMatch(t, wantFieldNames, log.Logs[0].FieldNames)
+	assert.ElementsMatch(t, wantFieldNames, log.Logs[0].FieldsAdded)
 }
 
 func logLevelStr(lvl gormlogger.LogLevel) string {


### PR DESCRIPTION
## Summary

Adds easy integration for Gin-Gonic & GORM with wharf-core's logging. See the _example_test.go files for how they're meant to be used, but here's the gist:

```go
// Gin-Gonic
r := gin.New()

r.Use(ginutil.DefaultLoggerHandler)
gin.DefaultWriter = ginutil.DefaultLoggerWriter
gin.DefaultErrorWriter = ginutil.DefaultLoggerWriter

// GORM
db, err := gorm.Open(postgres.Open("host=localhost"), &gorm.Config{
	DryRun:               true,
	DisableAutomaticPing: true,
	Logger: gormutil.NewLogger(gormutil.LoggerConfig{
		Logger: logger.NewScoped("GORM"),
	}),
})
```

## Motivation

GORM and Gin still has their built-in ways for logging, but allow you to add your own logger if you want to. These changes makes that integration easy, so with just a few lines then both GORM and Gin will use wharf-core/pkg/logger for logging instead of their own solutions, which will bring a more unified visual to our logs