### PR TITLE
Added problem util funcs from iver-wharf/wharf-api-client-go#12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   compatible `problem.Response`, originally taken from
   [wharf-api](https://github.com/iver-wharf/wharf-api). (#9)
 
+- Added utility to `pkg/problem` to identify and parse HTTP problem responses
+  and made `problem.Response` conform to `error` and `fmt.Stringer` interfaces.
+  (#12)
+
 - Added `pkg/logger`, `pkg/logger/consolepretty`, and `pkg/logger/consolejson`
   as fast, low memory using, extensible, and highly customizable logging
   libraries. Heavily inspired by [rs/zerolog](https://github.com/rs/zerolog).

--- a/pkg/ginutil/writeproblem.go
+++ b/pkg/ginutil/writeproblem.go
@@ -44,7 +44,7 @@ func WriteProblem(c *gin.Context, prob problem.Response) {
 	if len(prob.Errors) == 0 && len(c.Errors) > 0 {
 		prob.Errors = c.Errors.Errors()
 	}
-	c.Header("Content-Type", "application/problem+json")
+	c.Header("Content-Type", problem.HTTPContentType)
 	c.JSON(prob.Status, prob)
 }
 

--- a/pkg/problem/response_example_test.go
+++ b/pkg/problem/response_example_test.go
@@ -1,0 +1,49 @@
+package problem_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/iver-wharf/wharf-core/pkg/problem"
+)
+
+func ExampleParseHTTPResponse() {
+	req := httptest.NewRequest("GET", "/projects/123", nil)
+
+	// Faking a HTTP response here
+	req.Response = &http.Response{
+		Body: io.NopCloser(strings.NewReader(`
+{
+  "type": "https://iver-wharf.github.io/#/prob/build/run/invalid-input",
+  "title": "Invalid input variable for build.",
+  "status": 400,
+  "detail": "Build requires input variable 'myInput' to be of type 'string', but got 'int' instead.",
+  "instance": "/projects/12345/builds/run/6789",
+  "errors": [
+    "strconv.ParseUint: parsing \"-1\": invalid syntax"
+  ]
+}
+`)),
+		Header: make(http.Header),
+	}
+	req.Response.Header.Add("Content-Type", problem.HTTPContentType)
+
+	if problem.IsHTTPResponse(req.Response) {
+		p, err := problem.ParseHTTPResponse(req.Response)
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Println(p.String())
+	}
+
+	// Output:
+	// {(problem) HTTP 400, https://iver-wharf.github.io/#/prob/build/run/invalid-input
+	//     Title: Invalid input variable for build.
+	//    Detail: Build requires input variable 'myInput' to be of type 'string', but got 'int' instead.
+	//  Error(s): [strconv.ParseUint: parsing "-1": invalid syntax]
+	//  Instance: /projects/12345/builds/run/6789 }
+}

--- a/pkg/problem/response_test.go
+++ b/pkg/problem/response_test.go
@@ -1,0 +1,106 @@
+package problem
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"testing/iotest"
+)
+
+func TestIsHTTPResponse(t *testing.T) {
+	var testCases = []struct {
+		name   string
+		header http.Header
+		want   bool
+	}{
+		{
+			name:   "nil header",
+			header: nil,
+			want:   false,
+		},
+		{
+			name:   "empty header",
+			header: nil,
+			want:   false,
+		},
+		{
+			name:   "problem content-type",
+			header: newHeader("Content-Type", HTTPContentType),
+			want:   true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &http.Response{
+				Header: tc.header,
+			}
+			got := IsHTTPResponse(resp)
+			if got != tc.want {
+				t.Errorf("wanted %t, got: %t", tc.want, got)
+			}
+		})
+	}
+}
+
+func newHeader(key, value string) http.Header {
+	h := make(http.Header)
+	h.Add(key, value)
+	return h
+}
+
+func TestParseHTTPResponse_fail(t *testing.T) {
+	var testErr = errors.New("test err")
+	var testCases = []struct {
+		name   string
+		reader io.ReadCloser
+		errIs  error
+		errAs  error
+	}{
+		{
+			name:   "read",
+			reader: io.NopCloser(iotest.ErrReader(testErr)),
+			errIs:  testErr,
+		},
+		{
+			name:   "close",
+			reader: errCloser{strings.NewReader(""), testErr},
+			errIs:  testErr,
+		},
+		{
+			name:   "parse",
+			reader: io.NopCloser(strings.NewReader("???")),
+			errAs:  &json.SyntaxError{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var response = &http.Response{
+				Body: tc.reader,
+			}
+			_, err := ParseHTTPResponse(response)
+			if err == nil {
+				t.Error("wanted error, got nil")
+			}
+			if tc.errIs != nil {
+				if !errors.Is(err, tc.errIs) {
+					t.Errorf("wanted: %s; got: %s", tc.errIs, err)
+				}
+			} else {
+				if !errors.As(err, &tc.errAs) {
+					t.Errorf("wanted: %T; got: %s", tc.errAs, err)
+				}
+			}
+		})
+	}
+}
+
+type errCloser struct {
+	reader io.Reader
+	err    error
+}
+
+func (e errCloser) Read(p []byte) (n int, err error) { return e.reader.Read(p) }
+func (e errCloser) Close() error                     { return e.err }

--- a/pkg/strutil/strutil.go
+++ b/pkg/strutil/strutil.go
@@ -1,0 +1,39 @@
+package strutil
+
+import (
+	"fmt"
+	"unicode"
+	"unicode/utf8"
+)
+
+// FirstRuneLower returns the same string but with the first rune in the string
+// transformed to lowercase.
+func FirstRuneLower(value string) string {
+	if len(value) == 0 {
+		return value
+	}
+	first, size := utf8.DecodeRuneInString(value)
+	if first == utf8.RuneError {
+		return value
+	}
+	if unicode.IsLower(first) {
+		return value
+	}
+	return fmt.Sprintf("%c%s", unicode.ToLower(first), value[size:])
+}
+
+// FirstRuneUpper returns the same string but with the first rune in the string
+// transformed to uppercase.
+func FirstRuneUpper(value string) string {
+	if len(value) == 0 {
+		return value
+	}
+	first, size := utf8.DecodeRuneInString(value)
+	if first == utf8.RuneError {
+		return value
+	}
+	if unicode.IsUpper(first) {
+		return value
+	}
+	return fmt.Sprintf("%c%s", unicode.ToUpper(first), value[size:])
+}

--- a/pkg/strutil/strutil.go
+++ b/pkg/strutil/strutil.go
@@ -9,31 +9,23 @@ import (
 // FirstRuneLower returns the same string but with the first rune in the string
 // transformed to lowercase.
 func FirstRuneLower(value string) string {
-	if len(value) == 0 {
-		return value
-	}
 	first, size := utf8.DecodeRuneInString(value)
-	if first == utf8.RuneError {
+	if first == utf8.RuneError || unicode.IsLower(first) {
 		return value
 	}
-	if unicode.IsLower(first) {
-		return value
-	}
-	return fmt.Sprintf("%c%s", unicode.ToLower(first), value[size:])
+	return concatRuneString(unicode.ToLower(first), value[size:])
 }
 
 // FirstRuneUpper returns the same string but with the first rune in the string
 // transformed to uppercase.
 func FirstRuneUpper(value string) string {
-	if len(value) == 0 {
-		return value
-	}
 	first, size := utf8.DecodeRuneInString(value)
-	if first == utf8.RuneError {
+	if first == utf8.RuneError || unicode.IsUpper(first) {
 		return value
 	}
-	if unicode.IsUpper(first) {
-		return value
-	}
-	return fmt.Sprintf("%c%s", unicode.ToUpper(first), value[size:])
+	return concatRuneString(unicode.ToUpper(first), value[size:])
+}
+
+func concatRuneString(r rune, s string) string {
+	return fmt.Sprintf("%c%s", r, s)
 }

--- a/pkg/strutil/strutil_example_test.go
+++ b/pkg/strutil/strutil_example_test.go
@@ -1,0 +1,19 @@
+package strutil_test
+
+import (
+	"fmt"
+
+	"github.com/iver-wharf/wharf-core/pkg/strutil"
+)
+
+func ExampleFirstRuneUpper() {
+	fmt.Println(strutil.FirstRuneUpper("hello world"))
+	// Output:
+	// Hello world
+}
+
+func ExampleFirstRuneLower() {
+	fmt.Println(strutil.FirstRuneLower("HELLO WORLD"))
+	// Output:
+	// hELLO WORLD
+}


### PR DESCRIPTION
> Based on comment by @Pikabanga: https://github.com/iver-wharf/wharf-api-client-go/pull/12/files/2a6a9a2618d9b66093a7390771b0f4b8b710d5e2#r663710862

Basic functions to test if a HTTP response is a problem type as well as a parser func.

Also added the `problem.Response.Error()` and `.String()` so that the `problem.Response` conforms to the `error` and `strings.Stringer` interfaces.

Should it maybe just be `problem.Parse` but accept a byte slice instead?
