### PR TITLE
Added Event.WithStringer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,4 +29,4 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added `pkg/logger`, `pkg/logger/consolepretty`, and `pkg/logger/consolejson`
   as fast, low memory using, extensible, and highly customizable logging
   libraries. Heavily inspired by [rs/zerolog](https://github.com/rs/zerolog).
-  (#10)
+  (#10, #15)

--- a/pkg/logger/event.go
+++ b/pkg/logger/event.go
@@ -53,6 +53,11 @@ type Event interface {
 	// multiple times with the same key may lead to unexpected behaviour.
 	WithString(key string, value string) Event
 
+	// WithStringer adds a string field to this logged message using the value
+	// from fmt.Stringer.String(). Calling this method multiple times with the
+	// same key may lead to unexpected behaviour.
+	WithStringer(key string, value fmt.Stringer) Event
+
 	// WithRune adds a rune field to this logged message. Calling this method
 	// multiple times with the same key may lead to unexpected behaviour.
 	WithRune(key string, value rune) Event
@@ -203,6 +208,13 @@ func (ev event) WithScope(value string) Event {
 
 func (ev event) WithString(key string, value string) Event {
 	return ev.with(func(ctx Context) Context { return ctx.AppendString(key, value) })
+}
+
+func (ev event) WithStringer(key string, value fmt.Stringer) Event {
+	if len(ev.ctxs) > 0 {
+		return ev.WithString(key, value.String())
+	}
+	return ev
 }
 
 func (ev event) WithRune(key string, value rune) Event {


### PR DESCRIPTION
Useful for enums and similar.

Example:

```go
log.Info().
	WithString("level", level.String()).
	Message("Set logging level.")

// vs

log.Info().
	WithStringer("level", level).
	Message("Set logging level.")
```
