### PR TITLE
Fixed example test name config_test.ExampleNewBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,13 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Added `pkg/config` with newly added `config.Config` interface and
   implementation to let you load configs from environment variables or YAML
-  files. This is done via [spf13/viper](https://github.com/spf13/viper). (#4)
+  files. This is done via [spf13/viper](https://github.com/spf13/viper).
+  (#4, #16)
 
 - Added `pkg/problem` and `pkg/ginutil` to easily use the IETF RFC-7808
   compatible `problem.Response`, originally taken from
   [wharf-api](https://github.com/iver-wharf/wharf-api). (#9)
-  
+
 - Added `pkg/logger`, `pkg/logger/consolepretty`, and `pkg/logger/consolejson`
   as fast, low memory using, extensible, and highly customizable logging
   libraries. Heavily inspired by [rs/zerolog](https://github.com/rs/zerolog).

--- a/pkg/config/config_example_test.go
+++ b/pkg/config/config_example_test.go
@@ -41,7 +41,7 @@ var defaultConfig = Config{
 //go:embed testdata/embedded-config.yml
 var embeddedConfig []byte
 
-func ExampleConfig() {
+func ExampleNewBuilder() {
 	cfgBuilder := config.NewBuilder(defaultConfig)
 	cfgBuilder.AddConfigYAML(bytes.NewReader(embeddedConfig))
 	cfgBuilder.AddConfigYAMLFile("/etc/my-app/config.yml")


### PR DESCRIPTION
Was missing the test from the pkg.go.dev because the example test didn't target any type.

Now it does, so it should land under the NewBuilder type.

https://pkg.go.dev/github.com/iver-wharf/wharf-core/pkg/config#NewBuilder
