### PR TITLE
Added environment binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,6 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added new error response functions. (#17)
 
 - Added `pkg/env` to bind environment variable of a range of different types to
-  local variables. Usage is aimed towards backward compatibility with old
+  local variables. Usage is aimed towards backward compatability with old
   environment variables before the age of `pkg/config`, as the `pkg/config`
   already provides much better techniques for loading settings. (#18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   (#10, #13, #15, #20)
 
 - Added new error response functions. (#17)
+
+- Added `pkg/env` to bind environment variable of a range of different types to
+  local variables. Usage is aimed towards backward compatibility with old
+  environment variables before the age of `pkg/config`, as the `pkg/config`
+  already provides much better techniques for loading settings. (#18)

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,0 +1,13 @@
+package testutil
+
+import (
+	"os"
+	"testing"
+)
+
+// SetEnv sets the environment variable, and then unsets it when the test has
+// finished.
+func SetEnv(t *testing.T, key, value string) {
+	os.Setenv(key, value)
+	t.Cleanup(func() { os.Unsetenv(key) })
+}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -1,0 +1,187 @@
+package env
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"strconv"
+	"time"
+)
+
+// ErrUnsupportedType is returned when an environment variable target to bind is
+// not supported. For example a custom struct type.
+var ErrUnsupportedType = errors.New("unsupported type")
+
+// ErrNotAPointer is returned when an environment variable target to bind is not
+// a pointer. It's also a wrapped "unsupported type" error.
+var ErrNotAPointer = fmt.Errorf("%w: not a pointer", ErrUnsupportedType)
+
+// ErrParse is used in the ParseError type when checking error.Is to be able to
+// identify the error responses from the bind functions.
+var ErrParse = errors.New("failed to parse")
+
+// ParseError is an error type that unwraps to the internal parsing error
+// obtained.
+type ParseError struct {
+	EnvKey   string
+	EnvValue string
+	Err      error
+}
+
+// Error returns the error string. Makes it compliant with the error interface.
+func (err ParseError) Error() string {
+	return fmt.Sprintf("env %q=%q: %s", err.EnvKey, err.EnvValue, err.Err)
+}
+
+// Is returns true if the target error is ErrParse or if the inner actual
+// parsing error is the same error.
+//
+// This method provides compatibility with the errors.Is function.
+func (err ParseError) Is(target error) bool {
+	return errors.Is(ErrParse, target) || errors.Is(err.Err, target)
+}
+
+// As returns true if this error could be unwrapped into the type of the target
+// error.
+//
+// This method provides compatibility with the errors.As function.
+func (err ParseError) As(target interface{}) bool {
+	return errors.As(err.Err, target)
+}
+
+// Unwrap returns the inner actual parsing error, such as the error return value
+// from a strconv function.
+//
+// This method provides compatibility with the errors.Unwrap function.
+func (err ParseError) Unwrap() error {
+	return err.Err
+}
+
+// Bind will take a value pointer and depending on its type will try to parse
+// the environment variable, if set and not empty, using the appropriate parsing
+// function.
+//
+// If the environment variable is not set, is empty, or the function returns an
+// error, the value of the target interface is left unchanged.
+//
+// Returns an env.ParseError on parsing errors.
+//
+// Returns a wrapped env.ErrUnsupportedType error if the type of the interface
+// is not supported.
+//
+// Returns a wrapped env.ErrNotAPointer error if the target interface is not a
+// pointer.
+//
+// Returns nil otherwise.
+func Bind(i interface{}, key string) error {
+	var envStr, ok = LookupNoEmpty(key)
+	if !ok {
+		return nil
+	}
+	switch ptr := i.(type) {
+	case *string:
+		*ptr = envStr
+	case *bool:
+		value, err := strconv.ParseBool(envStr)
+		if err != nil {
+			return ParseError{key, envStr, err}
+		}
+		*ptr = value
+	case *int:
+		value, err := strconv.ParseInt(envStr, 10, strconv.IntSize)
+		if err != nil {
+			return ParseError{key, envStr, err}
+		}
+		*ptr = int(value)
+	case *int32:
+		value, err := strconv.ParseInt(envStr, 10, 32)
+		if err != nil {
+			return ParseError{key, envStr, err}
+		}
+		*ptr = int32(value)
+	case *int64:
+		value, err := strconv.ParseInt(envStr, 10, 64)
+		if err != nil {
+			return ParseError{key, envStr, err}
+		}
+		*ptr = value
+	case *uint:
+		value, err := strconv.ParseUint(envStr, 10, strconv.IntSize)
+		if err != nil {
+			return ParseError{key, envStr, err}
+		}
+		*ptr = uint(value)
+	case *uint32:
+		value, err := strconv.ParseUint(envStr, 10, 32)
+		if err != nil {
+			return ParseError{key, envStr, err}
+		}
+		*ptr = uint32(value)
+	case *uint64:
+		value, err := strconv.ParseUint(envStr, 10, 64)
+		if err != nil {
+			return ParseError{key, envStr, err}
+		}
+		*ptr = value
+	case *float32:
+		value, err := strconv.ParseFloat(envStr, 32)
+		if err != nil {
+			return ParseError{key, envStr, err}
+		}
+		*ptr = float32(value)
+	case *float64:
+		value, err := strconv.ParseFloat(envStr, 64)
+		if err != nil {
+			return ParseError{key, envStr, err}
+		}
+		*ptr = value
+	case *time.Time:
+		value, err := time.Parse(time.RFC3339, envStr)
+		if err != nil {
+			return ParseError{key, envStr, err}
+		}
+		*ptr = value
+	case *time.Duration:
+		value, err := time.ParseDuration(envStr)
+		if err != nil {
+			return ParseError{key, envStr, err}
+		}
+		*ptr = value
+	default:
+		if reflect.TypeOf(i).Kind() != reflect.Ptr {
+			return fmt.Errorf("env %q: %w: %T", key, ErrNotAPointer, i)
+		}
+		return fmt.Errorf("env %q: %w: %T", key, ErrUnsupportedType, i)
+	}
+	return nil
+}
+
+// BindMultiple updates the Go variables via the pointers with the values of the
+// environment variables, if set and not empty, for each respective pair in
+// the map.
+//
+// If the environment variable is not set, is empty, or the function returns an
+// error, the value of the respective target interface is left unchanged.
+//
+// An error is returned if any of the bindings failed to bind.
+func BindMultiple(bindings map[interface{}]string) error {
+	for ptr, key := range bindings {
+		if err := Bind(ptr, key); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// LookupNoEmpty retrieves the value of the environment variable.
+//
+// Returns ("", false) if the environment variable was empty, or not set.
+// Returns (envVariableValue, true) otherwise.
+func LookupNoEmpty(key string) (string, bool) {
+	var str, ok = os.LookupEnv(key)
+	if str == "" {
+		return "", false
+	}
+	return str, ok
+}

--- a/pkg/env/env_example_test.go
+++ b/pkg/env/env_example_test.go
@@ -1,0 +1,50 @@
+package env_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/iver-wharf/wharf-core/pkg/env"
+)
+
+func ExampleBind() {
+	os.Setenv("A", "1")
+	os.Setenv("B", "2")
+
+	type testType struct {
+		A string
+		B int
+		C time.Duration
+	}
+
+	var x testType
+
+	fmt.Printf("Before: A: %q\n", x.A)
+	fmt.Printf("Before: B: %d\n", x.B)
+
+	err := env.Bind(x.A, "A")
+	fmt.Printf("Parse A: %s (is ErrNotAPointer? %t)\n", err, errors.Is(err, env.ErrNotAPointer))
+	err = env.Bind(&x, "A")
+	fmt.Printf("Parse A: %s (is ErrUnsupportedType? %t)\n", err, errors.Is(err, env.ErrUnsupportedType))
+
+	env.Bind(&x.A, "A")
+	env.Bind(&x.B, "B")
+
+	fmt.Printf("After: A: %q\n", x.A)
+	fmt.Printf("After: B: %d\n", x.B)
+
+	os.Setenv("C", "foo bar")
+	err = env.Bind(&x.C, "C")
+	fmt.Printf("Parse C: %s (is ErrParse? %t)\n", err, errors.Is(err, env.ErrParse))
+
+	// Output:
+	// Before: A: ""
+	// Before: B: 0
+	// Parse A: env "A": unsupported type: not a pointer: string (is ErrNotAPointer? true)
+	// Parse A: env "A": unsupported type: *env_test.testType (is ErrUnsupportedType? true)
+	// After: A: "1"
+	// After: B: 2
+	// Parse C: env "C"="foo bar": time: invalid duration "foo bar" (is ErrParse? true)
+}

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -1,0 +1,53 @@
+package env
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/iver-wharf/wharf-core/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testBind(t *testing.T, ptr interface{}, envKey string, envValue string, want interface{}) {
+	t.Run(envKey, func(t *testing.T) {
+		testutil.SetEnv(t, envKey, envValue)
+		require.NoError(t, Bind(ptr, envKey))
+		// dereference the pointer inside the interface,
+		// turning e.g. interface{*int} into interface{int}
+		got := reflect.ValueOf(ptr).Elem().Interface()
+		assert.Equal(t, want, got)
+	})
+}
+
+func TestBind(t *testing.T) {
+	var (
+		myString   string
+		myBool     bool
+		myInt      int
+		myInt32    int32
+		myInt64    int64
+		myUint     uint
+		myUint32   uint32
+		myUint64   uint64
+		myFloat32  float32
+		myFloat64  float64
+		myDuration time.Duration
+	)
+	testBind(t, &myString, "MY_STR", "bar", "bar")
+	testBind(t, &myBool, "MY_BOOL", "true", true)
+	testBind(t, &myInt, "MY_INT", "-123", int(-123))
+	testBind(t, &myInt32, "MY_INT32", "-123", int32(-123))
+	testBind(t, &myInt64, "MY_INT64", "-123", int64(-123))
+	testBind(t, &myUint, "MY_UINT", "123", uint(123))
+	testBind(t, &myUint32, "MY_UINT32", "123", uint32(123))
+	testBind(t, &myUint64, "MY_UINT64", "123", uint64(123))
+	testBind(t, &myFloat32, "MY_FLOAT32", "123.0", float32(123.0))
+	testBind(t, &myFloat64, "MY_FLOAT64", "123.0", float64(123.0))
+	testBind(t, &myDuration, "MY_DURATION", "5s", 5*time.Second)
+}
+
+func TestBindMultiple_noErrorOnNilMap(t *testing.T) {
+	assert.NoError(t, BindMultiple(nil))
+}


### PR DESCRIPTION
Taken from iver-wharf/wharf-api#38, but simplified to use interfaces more.

Interfaces are less performant, but here the readability wins over the performance, compared to the pkg/logger lib, as these functions are not aimed to be used as frequently as the logging.

Once merged, I can jump over to the wharf-api repo and refactor further.
