### PR TITLE
Added ginutil.RecoverProblem

### DIFF
--- a/pkg/ginutil/recover.go
+++ b/pkg/ginutil/recover.go
@@ -8,6 +8,9 @@ import (
 	"github.com/iver-wharf/wharf-core/pkg/problem"
 )
 
+// RecoverProblem is a Gin middleware that uses RecoverProblemHandle.
+var RecoverProblem = gin.CustomRecovery(RecoverProblemHandle)
+
 // RecoverProblemHandle writes a HTTP "Internal Server Error" problem response.
 // Meant to be used with the gin-gonic panic recover middleware.
 func RecoverProblemHandle(c *gin.Context, err interface{}) {

--- a/pkg/ginutil/recover_example_test.go
+++ b/pkg/ginutil/recover_example_test.go
@@ -5,6 +5,14 @@ import (
 	"github.com/iver-wharf/wharf-core/pkg/ginutil"
 )
 
+func ExampleRecoverProblem() {
+	r := gin.New()
+
+	r.Use(
+		ginutil.RecoverProblem,
+	)
+}
+
 func ExampleRecoverProblemHandle() {
 	r := gin.New()
 


### PR DESCRIPTION
It makes it easier to use.

Old usage:

```go
r := gin.New()
r.Use(
	gin.Logger,
	gin.CustomRecovery(ginutil.RecoverProblemHandle),
)
```

New usage:
```go
r := gin.New()
r.Use(
	gin.Logger,
	ginutil.RecoverProblem,
)
```
