### PR TITLE
Added SetLevel & SetLevelScoped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,6 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added `pkg/logger`, `pkg/logger/consolepretty`, and `pkg/logger/consolejson`
   as fast, low memory using, extensible, and highly customizable logging
   libraries. Heavily inspired by [rs/zerolog](https://github.com/rs/zerolog).
-  (#10, #13, #15)
+  (#10, #13, #15, #20)
 
 - Added new error response functions. (#17)

--- a/pkg/logger/consolejson/json.go
+++ b/pkg/logger/consolejson/json.go
@@ -172,9 +172,10 @@ type sink struct {
 
 // NewContext creates a new JSON-console logging Context using the
 // same configuration as the one given when creating the Sink.
-func (s sink) NewContext() logger.Context {
+func (s sink) NewContext(scope string) logger.Context {
 	return context{
 		Config: s.config,
+		scope:  scope,
 	}
 }
 
@@ -228,11 +229,6 @@ func (c context) WriteOut(level logger.Level, message string) {
 	buf = append(buf, "}\n"...)
 
 	os.Stdout.Write(buf)
-}
-
-func (c context) SetScope(value string) logger.Context {
-	c.scope = value
-	return c
 }
 
 func (c context) SetCaller(file string, line int) logger.Context {

--- a/pkg/logger/consolepretty/pretty.go
+++ b/pkg/logger/consolepretty/pretty.go
@@ -206,9 +206,10 @@ type sink struct {
 
 // NewContext creates a new pretty-console logging Context using the
 // same configuration as the one given when creating the Sink.
-func (s sink) NewContext() logger.Context {
+func (s sink) NewContext(scope string) logger.Context {
 	return context{
 		Config: s.config,
+		scope:  scope,
 	}
 }
 
@@ -317,11 +318,6 @@ func escapeString(value string) string {
 		return fmt.Sprintf("`%s`", escapeStringReplacer.Replace(value))
 	}
 	return value
-}
-
-func (c context) SetScope(value string) logger.Context {
-	c.scope = value
-	return c
 }
 
 func (c context) SetCaller(file string, line int) logger.Context {

--- a/pkg/logger/context.go
+++ b/pkg/logger/context.go
@@ -28,15 +28,6 @@ type Context interface {
 	// Append... methods
 	WriteOut(level Level, message string)
 
-	// SetScope sets the scope value for this context.
-	//
-	// Calling this method multiple times shall override the previous value.
-	// An empty string signifies to unset this field.
-	//
-	// In contrast to AppendString, the logging sink is allowed to render this
-	// differently. E.g. some may render it as yet another field named "scope",
-	// others may render it as a specific HTTP header in a request.
-	SetScope(value string) Context
 	// SetCaller sets the caller and its line value for this context.
 	//
 	// Calling this method multiple times shall override the previous value.

--- a/pkg/logger/level.go
+++ b/pkg/logger/level.go
@@ -13,15 +13,18 @@ const (
 	// LevelDebug is the "debugging" logging level, and also the lowest logging
 	// level available.
 	LevelDebug Level = iota
-	// LevelInfo is the "information" logging level
+	// LevelInfo is the "information" logging level.
 	LevelInfo
-	// LevelWarn is the "warning" logging level
+	// LevelWarn is the "warning" logging level.
 	LevelWarn
-	// LevelError is the "error" logging level
+	// LevelError is the "error" logging level.
 	LevelError
 	// LevelPanic is the "panic" logging level, and also the highest logging
 	// level available.
 	LevelPanic
+	// LevelSilence will disable logging when used to configure an output, a
+	// scoped minimum logging level, or the global minimum logging level.
+	LevelSilence
 )
 
 // String returns a readable representation of the logging level.

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,0 +1,67 @@
+package logger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func reset() {
+	minGlobalLevel = LevelDebug
+	minScopedLevels = make(map[string]Level)
+	ClearOutputs()
+}
+
+func TestSetLevel(t *testing.T) {
+	t.Cleanup(reset)
+
+	mock := NewMock()
+	SetLevel(LevelWarn)
+	AddOutput(LevelDebug, mock)
+
+	log := New()
+	log.Debug().Message("Suppressed")
+	log.Warn().Message("Logged")
+
+	assert.ElementsMatch(t, mock.LogMessages, []string{"Logged"})
+}
+
+func TestSetLevelScoped(t *testing.T) {
+	t.Cleanup(reset)
+
+	mock := NewMock()
+	SetLevelScoped(LevelWarn, "MY-SCOPE")
+	AddOutput(LevelDebug, mock)
+
+	NewScoped("MY-SCOPE").Debug().Message("Suppressed")
+	NewScoped("MY-SCOPE").Warn().Message("Logged1")
+
+	New().Debug().Message("Logged2")
+	NewScoped("OTHER-SCOPE").Debug().Message("Logged3")
+
+	assert.ElementsMatch(t, mock.LogMessages, []string{"Logged1", "Logged2", "Logged3"})
+}
+
+func TestLevelSilence(t *testing.T) {
+	t.Cleanup(reset)
+
+	mock := NewMock()
+	AddOutput(LevelSilence, mock)
+
+	New().Error().Message("Suppressed")
+
+	assert.Len(t, mock.LogMessages, 0)
+}
+
+func TestLevelSilenceScoped(t *testing.T) {
+	t.Cleanup(reset)
+
+	mock := NewMock()
+	AddOutput(LevelDebug, mock)
+	SetLevelScoped(LevelSilence, "MY-SCOPE")
+
+	NewScoped("MY-SCOPE").Error().Message("Suppressed")
+	New().Error().Message("Logged")
+
+	assert.ElementsMatch(t, mock.LogMessages, []string{"Logged"})
+}


### PR DESCRIPTION
This allows users to change the logging level globally or on a per-scope basis.

To disable all GIN-debug logs, you would run:

```go
logger.SetLevelScoped(logger.LevelSilence, "GIN-debug")
```
