### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v1.1.0 (WIP)
+## v1.1.0 (2021-08-17)
 
 - Changed default field colors in `pkg/logger/consolepretty` from yellow to
   white. (#23)


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR

## Changes

- Changed default field colors in `pkg/logger/consolepretty` from yellow to
  white. (#23)

- Changed formatting in `pkg/logger/consolepretty` to have less whitespace
  around the scope and logging level, as well as adding padding and trimming to
  the caller so that it stays at a constant width for a given scope. (#23)

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
