### PR TITLE
Release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v1.2.0 (WIP)
+## v1.2.0 (2021-09-03)
 
 - Added `wharf-core/pkg/cacertutil`, taken from `wharf-api/internal/httputils`,
   in preparation to delete it from the wharf-api, wharf-provider-github,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v1.2.0 (2021-09-03)
+## v1.2.0 (2021-09-07)
 
 - Added `wharf-core/pkg/cacertutil`, taken from `wharf-api/internal/httputils`,
   in preparation to delete it from the wharf-api, wharf-provider-github,


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR

## Changes

- Added `wharf-core/pkg/cacertutil`, taken from `wharf-api/internal/httputils`,
  in preparation to delete it from the wharf-api, wharf-provider-github,
  wharf-provider-gitlab, and wharf-provider-azuredevops repos. (#27)

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
