### PR TITLE
Added Event.With

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v1.2.0 (2021-09-07)
-
-- Added `wharf-core/pkg/cacertutil`, taken from `wharf-api/internal/httputils`,
-  in preparation to delete it from the wharf-api, wharf-provider-github,
-  wharf-provider-gitlab, and wharf-provider-azuredevops repos. (#27)
+## v1.3.0 (WIP)
 
 - Added `Event.With(func(Event) Event) Event` to `wharf-core/pkg/logger` to
   make it easier to reuse field inside a certain scope: (#29)
@@ -32,6 +28,12 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
     log.Debug().With(logArgs).Message("Foo bar.")
   }
   ```
+
+## v1.2.0 (2021-09-07)
+
+- Added `wharf-core/pkg/cacertutil`, taken from `wharf-api/internal/httputils`,
+  in preparation to delete it from the wharf-api, wharf-provider-github,
+  wharf-provider-gitlab, and wharf-provider-azuredevops repos. (#27)
 
 ## v1.1.0 (2021-08-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v1.3.0 (WIP)
 
-- Added `Event.With(func(Event) Event) Event` to `wharf-core/pkg/logger` to
+- Added `Event.WithFunc(func(Event) Event) Event` to `wharf-core/pkg/logger` to
   make it easier to reuse field inside a certain scope: (#29)
 
   ```go
@@ -25,7 +25,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
         WithString("name", name)
     }
 
-    log.Debug().With(logArgs).Message("Foo bar.")
+    log.Debug().WithFunc(logArgs).Message("Foo bar.")
   }
   ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,21 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   in preparation to delete it from the wharf-api, wharf-provider-github,
   wharf-provider-gitlab, and wharf-provider-azuredevops repos. (#27)
 
+- Added `Event.With(func(Event) Event) Event` to `wharf-core/pkg/logger` to
+  make it easier to reuse field inside a certain scope: (#29)
+
+  ```go
+  func someFunc(group, name string) {
+    logArgs := func(ev logger.Event) logger.Event {
+      return ev.
+        WithString("group", group).
+        WithString("name", name)
+    }
+
+    log.Debug().With(logArgs).Message("Foo bar.")
+  }
+  ```
+
 ## v1.1.0 (2021-08-20)
 
 - Changed default field colors in `pkg/logger/consolepretty` from yellow to

--- a/pkg/logger/event.go
+++ b/pkg/logger/event.go
@@ -26,6 +26,11 @@ type Event interface {
 	// 	ev.WithString("hello", "world").Message("")
 	Message(message string)
 
+	// With applies a function to the event and then forwards the return value.
+	//
+	// Useful for reusing "with statements" for multiple logs.
+	With(f func(Event) Event) Event
+
 	// WithCaller adds a caller field to the log contexts inside this log event.
 	//
 	// This method is called automatically by NewEvent and all Logger methods,
@@ -196,6 +201,10 @@ func (ev event) returnPooledSlice() {
 	if ev.ctxs != nil {
 		contextPool.Put(ev.ctxs)
 	}
+}
+
+func (ev event) With(f func(Event) Event) Event {
+	return f(ev)
 }
 
 func (ev event) WithCaller(file string, line int) Event {

--- a/pkg/logger/event.go
+++ b/pkg/logger/event.go
@@ -26,10 +26,10 @@ type Event interface {
 	// 	ev.WithString("hello", "world").Message("")
 	Message(message string)
 
-	// With applies a function to the event and then forwards the return value.
+	// WithFunc applies a function to the event and then forwards the return value.
 	//
 	// Useful for reusing "with statements" for multiple logs.
-	With(f func(Event) Event) Event
+	WithFunc(f func(Event) Event) Event
 
 	// WithCaller adds a caller field to the log contexts inside this log event.
 	//
@@ -203,7 +203,7 @@ func (ev event) returnPooledSlice() {
 	}
 }
 
-func (ev event) With(f func(Event) Event) Event {
+func (ev event) WithFunc(f func(Event) Event) Event {
 	return f(ev)
 }
 


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added `logger.Event.WithFunc(func(Event) Event) Event`

## Motivation

Makes it easier to reuse logging fields, such as:

```go
func someFunc(group, name string) {
  log.Debug().
    WithString("group", group).
    WithString("name", name).
    Message("Foo bar.")

  log.Warn().
    WithString("group", group).
    WithString("name", name).
    Message("Oh no, but it's ok.")

  err := someOtherFunc(group, name)
  log.Error().
    WithString("group", group).
    WithString("name", name).
    WithError(err).
    Message("Oh no, it's not ok.")
}
```

vs:

```go
func someFunc(group, name string) {
  logArgs := func(ev logger.Event) logger.Event {
    return ev.
      WithString("group", group).
      WithString("name", name)
  }

  log.Debug().WithFunc(logArgs).Message("Foo bar.")

  log.Warn().WithFunc(logArgs).Message("Oh no, but it's ok.")

  err := someOtherFunc(group, name)
  log.Error().WithFunc(logArgs).WithError(err).Message("Oh no, it's not ok.")
}
```
