### PR TITLE
Added scope padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   }
   ```
 
+- Added `consolepretty.Config.ScopeMinLengthAuto` which will pad scopes
+  automatically based on the longest registered scope, or use the
+  `ScopeMinLength` and `ScopeMaxLength` configs to get more fine grained
+  control. (#32)
+
 ## v1.2.0 (2021-09-07)
 
 - Added `wharf-core/pkg/cacertutil`, taken from `wharf-api/internal/httputils`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added `consolepretty.Config.ScopeMinLengthAuto` which will pad scopes
   automatically based on the longest registered scope, or use the
   `ScopeMinLength` and `ScopeMaxLength` configs to get more fine grained
-  control. (#32)
+  control. The auto config is active by default. (#32)
 
 ## v1.2.0 (2021-09-07)
 

--- a/pkg/logger/consolepretty/pretty_example_test.go
+++ b/pkg/logger/consolepretty/pretty_example_test.go
@@ -18,3 +18,25 @@ func ExampleNew() {
 	// Output:
 	// foo:[DEBUG|consolepretty/pretty_example_test.go] Sample message.
 }
+
+func ExampleConfig_ScopeMinLengthAuto() {
+	defer logger.ClearOutputs()
+	logger.AddOutput(logger.LevelDebug, consolepretty.New(consolepretty.Config{
+		DisableDate:       true,
+		DisableCallerLine: true,
+
+		ScopeMinLengthAuto: true,
+	}))
+
+	log1 := logger.NewScoped("WHARF")
+	log2 := logger.NewScoped("GORM-debug")
+	log3 := logger.New()
+	log1.Debug().Message("Sample message.")
+	log2.Debug().Message("Sample message.")
+	log3.Debug().Message("Sample message.")
+
+	// Output:
+	// [DEBUG|WHARF     |consolepretty/pretty_example_test.go] Sample message.
+	// [DEBUG|GORM-debug|consolepretty/pretty_example_test.go] Sample message.
+	// [DEBUG|          |consolepretty/pretty_example_test.go] Sample message.
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -9,6 +9,11 @@ var (
 	minGlobalLevel  = LevelDebug
 	minScopedLevels = make(map[string]Level)
 	registeredSinks []registeredSink
+
+	// LongestScopeNameLength is updated whenever NewScoped is called, and is
+	// the string length of longest scope created. Useful when logging to align
+	// the scopes in the output by padding to obtain this width.
+	LongestScopeNameLength int
 )
 
 // SetLevel will suppress all events (no matter if scoped or not) that has a
@@ -56,6 +61,7 @@ type registeredSink struct {
 // example test.
 func ClearOutputs() {
 	registeredSinks = nil
+	LongestScopeNameLength = 0
 }
 
 // AddOutput registers a logging sink globally. Multiple sinks can be added, and
@@ -123,6 +129,9 @@ func New() Logger {
 // 	logger.NewScoped("GIN") // use when registering logger to gin-gonic
 // 	logger.New() // use in the apps top-level domain
 func NewScoped(scope string) Logger {
+	if len(scope) > LongestScopeNameLength {
+		LongestScopeNameLength = len(scope)
+	}
 	return logger{
 		newEvent: func(level Level, done DoneFunc) Event {
 			return NewEvent(level, scope, done)


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added configs to consolepretty sink:

  - `ScopeMaxLength`
  - `ScopeMinLength`
  - `ScopeMinLengthAuto`

- Added so consolepretty uses the above new configs to pad or trim the scopes, similar to how the caller is trimmed

## Motivation

Difficult to read:

```log
[DEBUG|WHARF|…example_test.go] Sample message.
[DEBUG|GORM-debug|…example_test.go] Sample message.
[DEBUG|…example_test.go] Sample message.
```

Easier to read:

```log
[DEBUG|WHARF     |…example_test.go] Sample message.
[DEBUG|GORM-debug|…example_test.go] Sample message.
[DEBUG|          |…example_test.go] Sample message.
```
