### PR TITLE
Configurable ellipsis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   `ScopeMinLength` and `ScopeMaxLength` configs to get more fine grained
   control. The auto config is active by default. (#32)
 
+- Added `consolepretty.Config.Ellipsis`, which defaults to the unicode ellipsis
+  character `…`, which is used when trimming is applied by `CallerMaxLength` and
+  `ScopeMaxLength`. (#33)
+
 ## v1.2.0 (2021-09-07)
 
 - Added `wharf-core/pkg/cacertutil`, taken from `wharf-api/internal/httputils`,

--- a/pkg/logger/consolepretty/pretty.go
+++ b/pkg/logger/consolepretty/pretty.go
@@ -259,6 +259,9 @@ func New(conf Config) logger.Sink {
 	if conf.DateFormat == "" {
 		conf.DateFormat = DefaultConfig.DateFormat
 	}
+	if conf.Ellipsis == "" {
+		conf.Ellipsis = DefaultConfig.Ellipsis
+	}
 	return sink{&conf}
 }
 

--- a/pkg/logger/consolepretty/pretty.go
+++ b/pkg/logger/consolepretty/pretty.go
@@ -164,6 +164,13 @@ type Config struct {
 	// 	Jan 02 15:04Z [INFO |example.go] Sample message.
 	DisableCallerLine bool
 
+	// Ellipsis defines the string used when trimming the values, as an effect
+	// of the caller or scope max length configs.
+	//
+	// Setting this to a value longer than the max length is considered
+	// undefined behavior, and should be avoided.
+	Ellipsis string
+
 	// CallerMaxLength will trim the caller file and line down to this length
 	// if set to a value of 1 or higher.
 	//
@@ -220,6 +227,7 @@ type Config struct {
 // unset. Changing this global value also changes the fallback values used in
 // New.
 var DefaultConfig = Config{
+	Ellipsis:           "…",
 	DateFormat:         "Jan-02 15:04Z0700",
 	CallerMaxLength:    23,
 	CallerMinLength:    23,
@@ -470,14 +478,12 @@ func (c context) writeLevel(w io.Writer, level logger.Level) {
 	}
 }
 
-const ellipsis = "…"
-
 func (c context) writeTrimmedRight(w io.Writer, col *color.Color, value string, maxLen int) int {
 	if written, ok := c.writeUntrimmedString(w, col, value, maxLen); ok {
 		return written
 	}
-	sliceLen := maxLen - 1 // -1 to make room for the ellipsis
-	col.Fprint(w, value[:sliceLen], ellipsis)
+	sliceLen := maxLen - len(c.Ellipsis)
+	col.Fprint(w, value[:sliceLen], c.Ellipsis)
 	return maxLen
 }
 
@@ -485,8 +491,8 @@ func (c context) writeTrimmedLeft(w io.Writer, col *color.Color, value string, m
 	if written, ok := c.writeUntrimmedString(w, col, value, maxLen); ok {
 		return written
 	}
-	sliceStartIndex := len(value) - maxLen + 1 // +1 to make room for the ellipsis
-	col.Fprint(w, ellipsis, value[sliceStartIndex:])
+	sliceStartIndex := len(value) - maxLen + len(c.Ellipsis)
+	col.Fprint(w, c.Ellipsis, value[sliceStartIndex:])
 	return maxLen
 }
 
@@ -499,9 +505,13 @@ func (c context) writeUntrimmedString(w io.Writer, col *color.Color, value strin
 	case valueLen == 0 || maxLen <= 0:
 		// do nothing
 		return 0, true
-	case maxLen == 1 && valueLen > 1:
-		col.Fprint(w, ellipsis)
-		return 1, true
+	case maxLen <= len(c.Ellipsis) && valueLen > len(c.Ellipsis):
+		maxEllipsisLen := len(c.Ellipsis)
+		if maxEllipsisLen > maxLen {
+			maxEllipsisLen = maxLen
+		}
+		col.Fprint(w, c.Ellipsis[:maxEllipsisLen])
+		return maxEllipsisLen, true
 	default:
 		col.Fprint(w, value)
 		return valueLen, true

--- a/pkg/logger/consolepretty/pretty_example_test.go
+++ b/pkg/logger/consolepretty/pretty_example_test.go
@@ -40,3 +40,19 @@ func ExampleConfig_ScopeMinLengthAuto() {
 	// [DEBUG|GORM-debug|consolepretty/pretty_example_test.go] Sample message.
 	// [DEBUG|          |consolepretty/pretty_example_test.go] Sample message.
 }
+
+func ExampleConfig_Ellipsis() {
+	defer logger.ClearOutputs()
+	logger.AddOutput(logger.LevelDebug, consolepretty.New(consolepretty.Config{
+		DisableDate:       true,
+		DisableCallerLine: true,
+
+		CallerMaxLength: 15,
+		Ellipsis:        consolepretty.DefaultConfig.Ellipsis,
+	}))
+
+	logger.New().Debug().Message("Sample message.")
+
+	// Output:
+	// [DEBUG|…mple_test.go] Sample message.
+}

--- a/pkg/logger/consolepretty/pretty_example_test.go
+++ b/pkg/logger/consolepretty/pretty_example_test.go
@@ -48,7 +48,7 @@ func ExampleConfig_Ellipsis() {
 		DisableCallerLine: true,
 
 		CallerMaxLength: 15,
-		Ellipsis:        consolepretty.DefaultConfig.Ellipsis,
+		//Ellipsis:        "…", // can be overridden
 	}))
 
 	logger.New().Debug().Message("Sample message.")


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed ellipsis to be configurable
- Changed trimming logic to support ellipsis characters longer than 1 rune
- Added example test

## Motivation

May want to change the default ellipsis unicode ellipsis character `…` to three dots `...` as not all terminals supports it. Just a "quality of life" config thing, IMO.
