### PR TITLE
Go 1.18

### DIFF
--- a/.github/workflows/go-format.yml
+++ b/.github/workflows/go-format.yml
@@ -11,8 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          stable: 'false'
-          go-version: '1.18.0-beta2'
+          go-version: '1.18'
 
       - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports@latest

--- a/.github/workflows/go-format.yml
+++ b/.github/workflows/go-format.yml
@@ -11,7 +11,8 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16'
+          stable: 'false'
+          go-version: '1.18.0-beta2'
 
       - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports@latest

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -12,8 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          stable: 'false'
-          go-version: '1.18.0-beta2'
+          go-version: '1.18'
 
       - name: Set up gotestfmt
         uses: haveyoudebuggedit/gotestfmt-action@v1

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -12,7 +12,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16'
+          stable: 'false'
+          go-version: '1.18.0-beta2'
 
       - name: Set up gotestfmt
         uses: haveyoudebuggedit/gotestfmt-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,13 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v2.0.0 (WIP)
 
-- BREAKING: Changed minor version of Go from 1.16 to 1.18. (#?)
+- BREAKING: Changed minor version of Go from 1.16 to 1.18. (#40)
+
+- BREAKING: Changed module path from `github.com/iver-wharf/wharf-core` to
+  `github.com/iver-wharf/wharf-core/v2`. (#40)
+
+- Changed `env.Bind` to use generic constraints for compile-time assertions
+  instead of runtime assertions. (#40)
 
 ## v1.3.0 (2021-11-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v2.0.0 (WIP)
+
+- BREAKING: Changed minor version of Go from 1.16 to 1.18. (#?)
+
 ## v1.3.0 (2021-11-30)
 
 - Added `Event.WithFunc(func(Event) Event) Event` to `wharf-core/pkg/logger` to

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ What you **will not** find in this repository:
 
 ## Development
 
-1. Install Go 1.16 or later: <https://golang.org/>
+1. Install Go 1.18 or later: <https://golang.org/>
 
 2. Install the [swaggo/swag](https://github.com/swaggo/swag) CLI globally:
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/iver-wharf/wharf-core
+module github.com/iver-wharf/wharf-core/v2
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/iver-wharf/wharf-core
 
-go 1.16
+go 1.18
 
 require (
 	github.com/fatih/color v1.12.0
@@ -11,4 +11,45 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gorm.io/driver/postgres v1.1.0
 	gorm.io/gorm v1.21.11
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/go-playground/locales v0.13.0 // indirect
+	github.com/go-playground/universal-translator v0.17.0 // indirect
+	github.com/go-playground/validator/v10 v10.4.1 // indirect
+	github.com/golang/protobuf v1.3.3 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
+	github.com/jackc/pgconn v1.8.1 // indirect
+	github.com/jackc/pgio v1.0.0 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgproto3/v2 v2.0.6 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
+	github.com/jackc/pgtype v1.7.0 // indirect
+	github.com/jackc/pgx/v4 v4.11.0 // indirect
+	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/jinzhu/now v1.1.2 // indirect
+	github.com/json-iterator/go v1.1.9 // indirect
+	github.com/leodido/go-urn v1.2.0 // indirect
+	github.com/magiconair/properties v1.8.1 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/pelletier/go-toml v1.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/afero v1.1.2 // indirect
+	github.com/spf13/cast v1.3.0 // indirect
+	github.com/spf13/jwalterweatherman v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.3 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/ugorji/go/codec v1.1.7 // indirect
+	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
+	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 // indirect
+	golang.org/x/text v0.3.3 // indirect
+	gopkg.in/ini.v1 v1.51.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -176,7 +176,6 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1 h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki7MGG8=
@@ -195,7 +194,6 @@ github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2 h1:JVX6jT/XfzNqIjye47
 github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2/go.mod h1:fGZlG77KXmcq05nJLRkk0+p82V8B8Dw8KN2/V9c/OAE=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
-github.com/jackc/pgproto3 v1.1.0 h1:FYYE4yRw+AgI8wXIinMlNjBbp/UitDJwfj5LqqewP1A=
 github.com/jackc/pgproto3 v1.1.0/go.mod h1:eR5FA3leWg7p9aeAqi37XOTgTIbkABlvcPB3E5rlc78=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190420180111-c116219b62db/go.mod h1:bhq50y+xrl9n5mRYyCBFKkpRVTLYJVWeCc+mEAI3yXA=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190609003834-432c2951c711/go.mod h1:uH0AWtUmuShn0bcesswc4aBTWGvw0cAxIJp+6OB//Wg=
@@ -410,7 +408,6 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=

--- a/pkg/app/example_version_gin_endpoint_test.go
+++ b/pkg/app/example_version_gin_endpoint_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/gin-gonic/gin"
-	"github.com/iver-wharf/wharf-core/pkg/app"
+	"github.com/iver-wharf/wharf-core/v2/pkg/app"
 )
 
 // The version.yaml file should be populated by a CI pipeline build step just

--- a/pkg/app/example_version_unmarshal_test.go
+++ b/pkg/app/example_version_unmarshal_test.go
@@ -3,7 +3,7 @@ package app_test
 import (
 	"fmt"
 
-	"github.com/iver-wharf/wharf-core/pkg/app"
+	"github.com/iver-wharf/wharf-core/v2/pkg/app"
 )
 
 func ExampleUnmarshalVersionYAML() {

--- a/pkg/cacertutil/httpclient.go
+++ b/pkg/cacertutil/httpclient.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/iver-wharf/wharf-core/pkg/logger"
+	"github.com/iver-wharf/wharf-core/v2/pkg/logger"
 )
 
 var log = logger.NewScoped("CA-CERT-UTIL")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -80,7 +80,7 @@ type Builder interface {
 	//
 	// The error that is returned is caused by any of the added config sources,
 	// such as from invalid YAML syntax in an added YAML file.
-	Unmarshal(config interface{}) error
+	Unmarshal(config any) error
 }
 
 // NewBuilder creates a new Builder based on a default configuration.
@@ -88,14 +88,14 @@ type Builder interface {
 // Due to technical limitations, it's vital that this default configuration is
 // of the same type that the config that you wish to unmarshal later, or at
 // least that it contains fields with the same names.
-func NewBuilder(defaultConfig interface{}) Builder {
+func NewBuilder(defaultConfig any) Builder {
 	return &builder{
 		defaultConfig: defaultConfig,
 	}
 }
 
 type builder struct {
-	defaultConfig interface{}
+	defaultConfig any
 	sources       []configSource
 }
 
@@ -116,7 +116,7 @@ func (b *builder) AddEnvironmentVariables(prefix string) {
 	b.sources = append(b.sources, envVarsSource{prefix})
 }
 
-func (b *builder) Unmarshal(config interface{}) error {
+func (b *builder) Unmarshal(config any) error {
 	v := viper.New()
 	initDefaults(v, b.defaultConfig)
 	for _, s := range b.sources {
@@ -127,7 +127,7 @@ func (b *builder) Unmarshal(config interface{}) error {
 	return v.Unmarshal(config)
 }
 
-func initDefaults(v *viper.Viper, defaultConfig interface{}) error {
+func initDefaults(v *viper.Viper, defaultConfig any) error {
 	// Uses a workaround to force viper to read environment variables
 	// by making it aware of all fields that exists so it can later map
 	// environment variables correctly.

--- a/pkg/config/config_example_test.go
+++ b/pkg/config/config_example_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/iver-wharf/wharf-core/pkg/config"
+	"github.com/iver-wharf/wharf-core/v2/pkg/config"
 )
 
 type Logging struct {

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"reflect"
 	"strconv"
 	"time"
 )
@@ -12,10 +11,6 @@ import (
 // ErrUnsupportedType is returned when an environment variable target to bind is
 // not supported. For example a custom struct type.
 var ErrUnsupportedType = errors.New("unsupported type")
-
-// ErrNotAPointer is returned when an environment variable target to bind is not
-// a pointer. It's also a wrapped "unsupported type" error.
-var ErrNotAPointer = fmt.Errorf("%w: not a pointer", ErrUnsupportedType)
 
 // ErrParse is used in the ParseError type when checking error.Is to be able to
 // identify the error responses from the bind functions.
@@ -58,6 +53,13 @@ func (err ParseError) Unwrap() error {
 	return err.Err
 }
 
+// BindConstraint is a generic type constraint of all the types that the Bind
+// function supports.
+type BindConstraint interface {
+	*string | *bool | *int | *int32 | *int64 | *uint | *uint32 | *uint64 |
+		*float32 | *float64 | *time.Time | *time.Duration
+}
+
 // Bind will take a value pointer and depending on its type will try to parse
 // the environment variable, if set and not empty, using the appropriate parsing
 // function.
@@ -74,12 +76,12 @@ func (err ParseError) Unwrap() error {
 // pointer.
 //
 // Returns nil otherwise.
-func Bind(i any, key string) error {
+func Bind[T BindConstraint](i T, key string) error {
 	var envStr, ok = LookupNoEmpty(key)
 	if !ok {
 		return nil
 	}
-	switch ptr := i.(type) {
+	switch ptr := (any)(i).(type) {
 	case *string:
 		*ptr = envStr
 	case *bool:
@@ -149,9 +151,6 @@ func Bind(i any, key string) error {
 		}
 		*ptr = value
 	default:
-		if reflect.TypeOf(i).Kind() != reflect.Ptr {
-			return fmt.Errorf("env %q: %w: %T", key, ErrNotAPointer, i)
-		}
 		return fmt.Errorf("env %q: %w: %T", key, ErrUnsupportedType, i)
 	}
 	return nil
@@ -165,7 +164,7 @@ func Bind(i any, key string) error {
 // error, the value of the respective target interface is left unchanged.
 //
 // An error is returned if any of the bindings failed to bind.
-func BindMultiple(bindings map[any]string) error {
+func BindMultiple[T BindConstraint](bindings map[T]string) error {
 	for ptr, key := range bindings {
 		if err := Bind(ptr, key); err != nil {
 			return err

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -46,7 +46,7 @@ func (err ParseError) Is(target error) bool {
 // error.
 //
 // This method provides compatibility with the errors.As function.
-func (err ParseError) As(target interface{}) bool {
+func (err ParseError) As(target any) bool {
 	return errors.As(err.Err, target)
 }
 
@@ -74,7 +74,7 @@ func (err ParseError) Unwrap() error {
 // pointer.
 //
 // Returns nil otherwise.
-func Bind(i interface{}, key string) error {
+func Bind(i any, key string) error {
 	var envStr, ok = LookupNoEmpty(key)
 	if !ok {
 		return nil
@@ -165,7 +165,7 @@ func Bind(i interface{}, key string) error {
 // error, the value of the respective target interface is left unchanged.
 //
 // An error is returned if any of the bindings failed to bind.
-func BindMultiple(bindings map[interface{}]string) error {
+func BindMultiple(bindings map[any]string) error {
 	for ptr, key := range bindings {
 		if err := Bind(ptr, key); err != nil {
 			return err

--- a/pkg/env/env_example_test.go
+++ b/pkg/env/env_example_test.go
@@ -24,11 +24,6 @@ func ExampleBind() {
 	fmt.Printf("Before: A: %q\n", x.A)
 	fmt.Printf("Before: B: %d\n", x.B)
 
-	err := env.Bind(x.A, "A")
-	fmt.Printf("Parse A: %s (is ErrNotAPointer? %t)\n", err, errors.Is(err, env.ErrNotAPointer))
-	err = env.Bind(&x, "A")
-	fmt.Printf("Parse A: %s (is ErrUnsupportedType? %t)\n", err, errors.Is(err, env.ErrUnsupportedType))
-
 	env.Bind(&x.A, "A")
 	env.Bind(&x.B, "B")
 
@@ -36,14 +31,12 @@ func ExampleBind() {
 	fmt.Printf("After: B: %d\n", x.B)
 
 	os.Setenv("C", "foo bar")
-	err = env.Bind(&x.C, "C")
+	err := env.Bind(&x.C, "C")
 	fmt.Printf("Parse C: %s (is ErrParse? %t)\n", err, errors.Is(err, env.ErrParse))
 
 	// Output:
 	// Before: A: ""
 	// Before: B: 0
-	// Parse A: env "A": unsupported type: not a pointer: string (is ErrNotAPointer? true)
-	// Parse A: env "A": unsupported type: *env_test.testType (is ErrUnsupportedType? true)
 	// After: A: "1"
 	// After: B: 2
 	// Parse C: env "C"="foo bar": time: invalid duration "foo bar" (is ErrParse? true)

--- a/pkg/env/env_example_test.go
+++ b/pkg/env/env_example_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/iver-wharf/wharf-core/pkg/env"
+	"github.com/iver-wharf/wharf-core/v2/pkg/env"
 )
 
 func ExampleBind() {

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testBind(t *testing.T, ptr interface{}, envKey string, envValue string, want interface{}) {
+func testBind(t *testing.T, ptr any, envKey string, envValue string, want any) {
 	t.Run(envKey, func(t *testing.T) {
 		testutil.SetEnv(t, envKey, envValue)
 		require.NoError(t, Bind(ptr, envKey))

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/iver-wharf/wharf-core/internal/testutil"
+	"github.com/iver-wharf/wharf-core/v2/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testBind(t *testing.T, ptr any, envKey string, envValue string, want any) {
+func testBind[T BindConstraint](t *testing.T, ptr T, envKey string, envValue string, want any) {
 	t.Run(envKey, func(t *testing.T) {
 		testutil.SetEnv(t, envKey, envValue)
 		require.NoError(t, Bind(ptr, envKey))
@@ -49,5 +49,5 @@ func TestBind(t *testing.T) {
 }
 
 func TestBindMultiple_noErrorOnNilMap(t *testing.T) {
-	assert.NoError(t, BindMultiple(nil))
+	assert.NoError(t, BindMultiple[*int](nil))
 }

--- a/pkg/ginutil/logger.go
+++ b/pkg/ginutil/logger.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
-	"github.com/iver-wharf/wharf-core/pkg/logger"
+	"github.com/iver-wharf/wharf-core/v2/pkg/logger"
 )
 
 // LoggerConfig holds configuration for the Gin logging integration.

--- a/pkg/ginutil/logger_example_test.go
+++ b/pkg/ginutil/logger_example_test.go
@@ -5,9 +5,9 @@ import (
 	"net/http/httptest"
 
 	"github.com/gin-gonic/gin"
-	"github.com/iver-wharf/wharf-core/pkg/ginutil"
-	"github.com/iver-wharf/wharf-core/pkg/logger"
-	"github.com/iver-wharf/wharf-core/pkg/logger/consolepretty"
+	"github.com/iver-wharf/wharf-core/v2/pkg/ginutil"
+	"github.com/iver-wharf/wharf-core/v2/pkg/logger"
+	"github.com/iver-wharf/wharf-core/v2/pkg/logger/consolepretty"
 )
 
 func init() {

--- a/pkg/ginutil/params.go
+++ b/pkg/ginutil/params.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"github.com/iver-wharf/wharf-core/pkg/problem"
+	"github.com/iver-wharf/wharf-core/v2/pkg/problem"
 )
 
 // RequireParamString tries to read the named path parameter from the request

--- a/pkg/ginutil/recover.go
+++ b/pkg/ginutil/recover.go
@@ -13,7 +13,7 @@ var RecoverProblem = gin.CustomRecovery(RecoverProblemHandle)
 
 // RecoverProblemHandle writes a HTTP "Internal Server Error" problem response.
 // Meant to be used with the gin-gonic panic recover middleware.
-func RecoverProblemHandle(c *gin.Context, err interface{}) {
+func RecoverProblemHandle(c *gin.Context, err any) {
 	WriteProblem(c, problem.Response{
 		Type:   "/prob/api/internal-server-error",
 		Title:  "Internal server error.",

--- a/pkg/ginutil/recover.go
+++ b/pkg/ginutil/recover.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/iver-wharf/wharf-core/pkg/problem"
+	"github.com/iver-wharf/wharf-core/v2/pkg/problem"
 )
 
 // RecoverProblem is a Gin middleware that uses RecoverProblemHandle.

--- a/pkg/ginutil/recover_example_test.go
+++ b/pkg/ginutil/recover_example_test.go
@@ -2,7 +2,7 @@ package ginutil_test
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/iver-wharf/wharf-core/pkg/ginutil"
+	"github.com/iver-wharf/wharf-core/v2/pkg/ginutil"
 )
 
 func ExampleRecoverProblem() {

--- a/pkg/ginutil/writeproblem.go
+++ b/pkg/ginutil/writeproblem.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 
 	"github.com/gin-gonic/gin"
-	"github.com/iver-wharf/wharf-core/pkg/problem"
+	"github.com/iver-wharf/wharf-core/v2/pkg/problem"
 )
 
 // WriteProblem writes the Problem as JSON into the output response body

--- a/pkg/ginutil/writeproblem_example_test.go
+++ b/pkg/ginutil/writeproblem_example_test.go
@@ -9,8 +9,8 @@ import (
 	"net/http/httptest"
 
 	"github.com/gin-gonic/gin"
-	"github.com/iver-wharf/wharf-core/pkg/ginutil"
-	"github.com/iver-wharf/wharf-core/pkg/problem"
+	"github.com/iver-wharf/wharf-core/v2/pkg/ginutil"
+	"github.com/iver-wharf/wharf-core/v2/pkg/problem"
 )
 
 func init() {

--- a/pkg/gormutil/logger.go
+++ b/pkg/gormutil/logger.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/iver-wharf/wharf-core/pkg/logger"
+	"github.com/iver-wharf/wharf-core/v2/pkg/logger"
 	"gorm.io/gorm"
 	gormlogger "gorm.io/gorm/logger"
 )

--- a/pkg/gormutil/logger.go
+++ b/pkg/gormutil/logger.go
@@ -61,19 +61,19 @@ func (log gormLog) LogMode(level gormlogger.LogLevel) gormlogger.Interface {
 	return log
 }
 
-func (log gormLog) Info(_ context.Context, message string, args ...interface{}) {
+func (log gormLog) Info(_ context.Context, message string, args ...any) {
 	if log.level >= gormlogger.Info || !log.AlsoUseGORMLogLevel {
 		log.Logger.Info().Messagef(message, args...)
 	}
 }
 
-func (log gormLog) Warn(_ context.Context, message string, args ...interface{}) {
+func (log gormLog) Warn(_ context.Context, message string, args ...any) {
 	if log.level >= gormlogger.Warn || !log.AlsoUseGORMLogLevel {
 		log.Logger.Warn().Messagef(message, args...)
 	}
 }
 
-func (log gormLog) Error(_ context.Context, message string, args ...interface{}) {
+func (log gormLog) Error(_ context.Context, message string, args ...any) {
 	if log.level >= gormlogger.Error || !log.AlsoUseGORMLogLevel {
 		log.Logger.Error().Messagef(message, args...)
 	}

--- a/pkg/gormutil/logger_example_test.go
+++ b/pkg/gormutil/logger_example_test.go
@@ -3,9 +3,9 @@ package gormutil_test
 import (
 	"fmt"
 
-	"github.com/iver-wharf/wharf-core/pkg/gormutil"
-	"github.com/iver-wharf/wharf-core/pkg/logger"
-	"github.com/iver-wharf/wharf-core/pkg/logger/consolepretty"
+	"github.com/iver-wharf/wharf-core/v2/pkg/gormutil"
+	"github.com/iver-wharf/wharf-core/v2/pkg/logger"
+	"github.com/iver-wharf/wharf-core/v2/pkg/logger/consolepretty"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )

--- a/pkg/gormutil/logger_test.go
+++ b/pkg/gormutil/logger_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/iver-wharf/wharf-core/pkg/logger"
+	"github.com/iver-wharf/wharf-core/v2/pkg/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/postgres"

--- a/pkg/logger/consolejson/json.go
+++ b/pkg/logger/consolejson/json.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/iver-wharf/wharf-core/pkg/logger"
+	"github.com/iver-wharf/wharf-core/v2/pkg/logger"
 )
 
 // TimeFormat specifies the formatting used when logging time.Time values.

--- a/pkg/logger/consolejson/json_example_test.go
+++ b/pkg/logger/consolejson/json_example_test.go
@@ -3,8 +3,8 @@ package consolejson_test
 import (
 	"time"
 
-	"github.com/iver-wharf/wharf-core/pkg/logger"
-	"github.com/iver-wharf/wharf-core/pkg/logger/consolejson"
+	"github.com/iver-wharf/wharf-core/v2/pkg/logger"
+	"github.com/iver-wharf/wharf-core/v2/pkg/logger/consolejson"
 )
 
 func ExampleNew() {

--- a/pkg/logger/consolepretty/pretty.go
+++ b/pkg/logger/consolepretty/pretty.go
@@ -289,7 +289,7 @@ type context struct {
 
 type fieldPair struct {
 	key   string
-	value interface{}
+	value any
 }
 
 func (c context) WriteOut(level logger.Level, message string) {
@@ -380,7 +380,7 @@ func (c context) WriteOut(level logger.Level, message string) {
 	io.Copy(c.Writer, &buf)
 }
 
-func getPrintableStringRepresentation(value interface{}) (str string, hasValue bool) {
+func getPrintableStringRepresentation(value any) (str string, hasValue bool) {
 	if value == nil {
 		return "<nil>", false
 	}
@@ -439,7 +439,7 @@ func (c context) AppendFloat64(k string, v float64) logger.Context        { retu
 func (c context) AppendTime(k string, v time.Time) logger.Context         { return c.addField(k, v) }
 func (c context) AppendDuration(k string, v time.Duration) logger.Context { return c.addField(k, v) }
 
-func (c context) addField(key string, value interface{}) logger.Context {
+func (c context) addField(key string, value any) logger.Context {
 	c.fields = append(c.fields, fieldPair{key, value})
 	return c
 }

--- a/pkg/logger/consolepretty/pretty.go
+++ b/pkg/logger/consolepretty/pretty.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/fatih/color"
-	"github.com/iver-wharf/wharf-core/pkg/logger"
+	"github.com/iver-wharf/wharf-core/v2/pkg/logger"
 	"github.com/mattn/go-colorable"
 )
 

--- a/pkg/logger/consolepretty/pretty_example_test.go
+++ b/pkg/logger/consolepretty/pretty_example_test.go
@@ -1,8 +1,8 @@
 package consolepretty_test
 
 import (
-	"github.com/iver-wharf/wharf-core/pkg/logger"
-	"github.com/iver-wharf/wharf-core/pkg/logger/consolepretty"
+	"github.com/iver-wharf/wharf-core/v2/pkg/logger"
+	"github.com/iver-wharf/wharf-core/v2/pkg/logger/consolepretty"
 )
 
 func ExampleNew() {

--- a/pkg/logger/event.go
+++ b/pkg/logger/event.go
@@ -208,11 +208,11 @@ func (ev event) WithFunc(f func(Event) Event) Event {
 }
 
 func (ev event) WithCaller(file string, line int) Event {
-	return ev.with(func(ctx Context) Context { return ctx.SetCaller(file, line) })
+	return withKeyedFunc(ev, file, line, Context.SetCaller)
 }
 
 func (ev event) WithString(key string, value string) Event {
-	return ev.with(func(ctx Context) Context { return ctx.AppendString(key, value) })
+	return withKeyedFunc(ev, key, value, Context.AppendString)
 }
 
 func (ev event) WithStringf(key string, format string, args ...any) Event {
@@ -230,60 +230,78 @@ func (ev event) WithStringer(key string, value fmt.Stringer) Event {
 }
 
 func (ev event) WithRune(key string, value rune) Event {
-	return ev.with(func(ctx Context) Context { return ctx.AppendRune(key, value) })
+	return withKeyedFunc(ev, key, value, Context.AppendRune)
 }
 
 func (ev event) WithBool(key string, value bool) Event {
-	return ev.with(func(ctx Context) Context { return ctx.AppendBool(key, value) })
+	return withKeyedFunc(ev, key, value, Context.AppendBool)
 }
 
 func (ev event) WithInt(key string, value int) Event {
-	return ev.with(func(ctx Context) Context { return ctx.AppendInt(key, value) })
+	return withKeyedFunc(ev, key, value, Context.AppendInt)
 }
 
 func (ev event) WithInt64(key string, value int64) Event {
-	return ev.with(func(ctx Context) Context { return ctx.AppendInt64(key, value) })
+	return withKeyedFunc(ev, key, value, Context.AppendInt64)
 }
 
 func (ev event) WithInt32(key string, value int32) Event {
-	return ev.with(func(ctx Context) Context { return ctx.AppendInt32(key, value) })
+	return withKeyedFunc(ev, key, value, Context.AppendInt32)
 }
 
 func (ev event) WithUint(key string, value uint) Event {
-	return ev.with(func(ctx Context) Context { return ctx.AppendUint(key, value) })
+	return withKeyedFunc(ev, key, value, Context.AppendUint)
 }
 
 func (ev event) WithUint64(key string, value uint64) Event {
-	return ev.with(func(ctx Context) Context { return ctx.AppendUint64(key, value) })
+	return withKeyedFunc(ev, key, value, Context.AppendUint64)
 }
 
 func (ev event) WithUint32(key string, value uint32) Event {
-	return ev.with(func(ctx Context) Context { return ctx.AppendUint32(key, value) })
+	return withKeyedFunc(ev, key, value, Context.AppendUint32)
 }
 
 func (ev event) WithFloat32(key string, value float32) Event {
-	return ev.with(func(ctx Context) Context { return ctx.AppendFloat32(key, value) })
+	return withKeyedFunc(ev, key, value, Context.AppendFloat32)
 }
 
 func (ev event) WithFloat64(key string, value float64) Event {
-	return ev.with(func(ctx Context) Context { return ctx.AppendFloat64(key, value) })
+	return withKeyedFunc(ev, key, value, Context.AppendFloat64)
 }
 
 func (ev event) WithError(value error) Event {
-	return ev.with(func(ctx Context) Context { return ctx.SetError(value) })
+	return withFunc(ev, value, Context.SetError)
 }
 
 func (ev event) WithTime(key string, value time.Time) Event {
-	return ev.with(func(ctx Context) Context { return ctx.AppendTime(key, value) })
+	return withKeyedFunc(ev, key, value, Context.AppendTime)
 }
 
 func (ev event) WithDuration(key string, value time.Duration) Event {
-	return ev.with(func(ctx Context) Context { return ctx.AppendDuration(key, value) })
+	return withKeyedFunc(ev, key, value, Context.AppendDuration)
 }
 
 func (ev event) with(f func(Context) Context) Event {
 	for i, ctx := range ev.ctxs {
 		ev.ctxs[i] = f(ctx)
+	}
+	return ev
+}
+
+type contextFunc[T any] func(ctx Context, value T) Context
+
+func withFunc[T any](ev event, value T, f contextFunc[T]) event {
+	for i, ctx := range ev.ctxs {
+		ev.ctxs[i] = f(ctx, value)
+	}
+	return ev
+}
+
+type contextKeyedFunc[T any] func(ctx Context, key string, value T) Context
+
+func withKeyedFunc[T any](ev event, key string, value T, f contextKeyedFunc[T]) event {
+	for i, ctx := range ev.ctxs {
+		ev.ctxs[i] = f(ctx, key, value)
 	}
 	return ev
 }

--- a/pkg/logger/event.go
+++ b/pkg/logger/event.go
@@ -18,7 +18,7 @@ type DoneFunc func(message string)
 type Event interface {
 	// Messagef submits this log event to the different sinks using a formatted
 	// message. The formatting is the same applied from the fmt package.
-	Messagef(format string, args ...interface{})
+	Messagef(format string, args ...any)
 
 	// Message submits this log event to the different sinks using a message. To
 	// submit without a message you may pass an empty string into this method, like
@@ -48,7 +48,7 @@ type Event interface {
 	// WithStringf adds a formatted string field to this logged message. The
 	// formatting is the same applied from the fmt package. Calling this method
 	// multiple times with the same key may lead to unexpected behaviour.
-	WithStringf(key string, format string, args ...interface{}) Event
+	WithStringf(key string, format string, args ...any) Event
 
 	// WithStringer adds a string field to this logged message using the value
 	// from fmt.Stringer.String(). Calling this method multiple times with the
@@ -119,7 +119,7 @@ type Event interface {
 }
 
 var contextPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return []Context{}
 	},
 }
@@ -176,7 +176,7 @@ func NewEventFromLogger(log Logger, level Level) Event {
 	}
 }
 
-func (ev event) Messagef(format string, args ...interface{}) {
+func (ev event) Messagef(format string, args ...any) {
 	if len(ev.ctxs) > 0 {
 		ev.Message(fmt.Sprintf(format, args...))
 	} else {
@@ -215,7 +215,7 @@ func (ev event) WithString(key string, value string) Event {
 	return ev.with(func(ctx Context) Context { return ctx.AppendString(key, value) })
 }
 
-func (ev event) WithStringf(key string, format string, args ...interface{}) Event {
+func (ev event) WithStringf(key string, format string, args ...any) Event {
 	if len(ev.ctxs) > 0 {
 		return ev.WithString(key, fmt.Sprintf(format, args...))
 	}

--- a/pkg/logger/event.go
+++ b/pkg/logger/event.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/iver-wharf/wharf-core/internal/traceutil"
+	"github.com/iver-wharf/wharf-core/v2/internal/traceutil"
 )
 
 // DoneFunc is the signature of the function that is called at the end of a

--- a/pkg/logger/level_example_test.go
+++ b/pkg/logger/level_example_test.go
@@ -3,7 +3,7 @@ package logger_test
 import (
 	"fmt"
 
-	"github.com/iver-wharf/wharf-core/pkg/logger"
+	"github.com/iver-wharf/wharf-core/v2/pkg/logger"
 )
 
 func ExampleLevel_String() {

--- a/pkg/logger/logger_example_test.go
+++ b/pkg/logger/logger_example_test.go
@@ -1,9 +1,9 @@
 package logger_test
 
 import (
-	"github.com/iver-wharf/wharf-core/pkg/logger"
-	"github.com/iver-wharf/wharf-core/pkg/logger/consolejson"
-	"github.com/iver-wharf/wharf-core/pkg/logger/consolepretty"
+	"github.com/iver-wharf/wharf-core/v2/pkg/logger"
+	"github.com/iver-wharf/wharf-core/v2/pkg/logger/consolejson"
+	"github.com/iver-wharf/wharf-core/v2/pkg/logger/consolepretty"
 )
 
 var prettyConf = consolepretty.Config{

--- a/pkg/logger/mock.go
+++ b/pkg/logger/mock.go
@@ -26,7 +26,7 @@ func NewMock() *Mock {
 func (log *Mock) NewContext(scope string) Context {
 	ctx := mockCtx{
 		MockLog: MockLog{
-			Fields: make(map[string]interface{}),
+			Fields: make(map[string]any),
 		},
 		logger: log,
 	}
@@ -52,7 +52,7 @@ type MockLog struct {
 	// 	Event.SetCaller("foo", 42)
 	// 		=> MockLog.Fields["caller"] = "foo"
 	// 		=> MockLog.Fields["line"] = 42
-	Fields map[string]interface{}
+	Fields map[string]any
 	// FieldsAdded is a slice of strings with all the keys added to the Fields
 	// map. This includes the custom mapping of Event.SetScope,
 	// Event.SetError, and Event.SetCaller as mentioned in the Fields docs.
@@ -130,7 +130,7 @@ func (c mockCtx) AppendFloat64(k string, v float64) Context        { return c.ad
 func (c mockCtx) AppendTime(k string, v time.Time) Context         { return c.addField(k, v) }
 func (c mockCtx) AppendDuration(k string, v time.Duration) Context { return c.addField(k, v) }
 
-func (c mockCtx) addField(key string, value interface{}) Context {
+func (c mockCtx) addField(key string, value any) Context {
 	c.Fields[key] = value
 	c.FieldsAdded = append(c.FieldsAdded, key)
 	return c

--- a/pkg/problem/response.go
+++ b/pkg/problem/response.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/iver-wharf/wharf-core/pkg/strutil"
+	"github.com/iver-wharf/wharf-core/v2/pkg/strutil"
 )
 
 // HTTPContentType is the value used in HTTP requests and responses for the

--- a/pkg/problem/response_example_test.go
+++ b/pkg/problem/response_example_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 
-	"github.com/iver-wharf/wharf-core/pkg/problem"
+	"github.com/iver-wharf/wharf-core/v2/pkg/problem"
 )
 
 func ExampleParseHTTPResponse() {

--- a/pkg/strutil/strutil_example_test.go
+++ b/pkg/strutil/strutil_example_test.go
@@ -3,7 +3,7 @@ package strutil_test
 import (
 	"fmt"
 
-	"github.com/iver-wharf/wharf-core/pkg/strutil"
+	"github.com/iver-wharf/wharf-core/v2/pkg/strutil"
 )
 
 func ExampleFirstRuneUpper() {


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs
- [x] ~~Will mark as ready as soon as Go 1.18 has hit GA.~~

## Summary

- Changed to Go 1.18 in go.mod
- Changed package to /v2
- Updated `CHANGELOG.md`
- Changed `interface{}` to `any`
- Changed logger to use generics internally
- Changed `env.Bind` to use generic instead of reflect for type assertion

## Motivation

I'm mostly playing around in this PR. Wanted to see what could make use of generics and what can't.

There's probably a lot of fun we could add into wharf-core that makes use of generics, but that'll be left for a future PR. Such as maybe rewriting the logger or some config utils to make use of generic? Don't see the need for it, but it's worth brainstorming.
