### PR TITLE
Moved linting to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,12 @@ deps:
 	npm install
 
 lint: lint-md lint-go
-lint-fix: lint-md-fix
+lint-fix: lint-fix-md
 
 lint-md:
 	npx remark . .github
 
-lint-md-fix:
+lint-fix-md:
 	npx remark . .github -o
 
 lint-go:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: check tidy deps \
+	lint lint-md lint-go \
+	lint-fix lint-md-fix
+
+check:
+	go test ./...
+
+tidy:
+	go mod tidy
+
+deps:
+	go install github.com/mgechev/revive@latest
+	go install golang.org/x/tools/cmd/goimports@latest
+	npm install
+
+lint: lint-md lint-go
+lint-fix: lint-md-fix
+
+lint-md:
+	npx remark . .github
+
+lint-md-fix:
+	npx remark . .github -o
+
+lint-go:
+	revive -formatter stylish -config revive.toml ./...

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: check tidy deps \
 	lint lint-md lint-go \
-	lint-fix lint-md-fix
+	lint-fix lint-fix-md lint-fix-go
 
 check:
 	go test ./...
@@ -23,4 +23,8 @@ lint-fix-md:
 	npx remark . .github -o
 
 lint-go:
+	goimports -d $(shell git ls-files "*.go")
 	revive -formatter stylish -config revive.toml ./...
+
+lint-fix-go:
+	goimports -d -w $(shell git ls-files "*.go")

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ deps:
 	npm install
 
 lint: lint-md lint-go
-lint-fix: lint-fix-md
+lint-fix: lint-fix-md lint-fix-go
 
 lint-md:
 	npx remark . .github

--- a/README.md
+++ b/README.md
@@ -78,43 +78,25 @@ Requires Go 1.16 or later to be installed: <https://golang.org/>
 go test -v ./...
 ```
 
-## Linting Golang
-
-- Requires Node.js (npm) to be installed: <https://nodejs.org/en/download/>
-- Requires Revive to be installed: <https://revive.run/>
-
-```sh
-go get -u github.com/mgechev/revive
-```
-
-```sh
-npm run lint-go
-```
-
-## Linting markdown
-
-- Requires Node.js (npm) to be installed: <https://nodejs.org/en/download/>
-
-```sh
-npm install
-
-npm run lint-md
-
-# Some errors can be fixed automatically. Keep in mind that this updates the
-# files in place.
-npm run lint-md-fix
-```
-
 ## Linting
 
 You can lint all of the above at the same time by running:
 
 ```sh
-npm run lint
+make lint
 
-# Some errors can be fixed automatically. Keep in mind that this updates the
-# files in place.
-npm run lint-fix
+make lint-go # only lint Go code
+make lint-md # only lint Markdown files
+```
+
+Some errors can be fixed automatically. Keep in mind that this updates the
+files in place.
+
+```sh
+make lint-fix
+
+#make lint-fix-go # Go linter does not support fixes
+make lint-fix-md # only lint and fix Markdown files
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ go test -v ./...
 
 ## Linting
 
-You can lint all of the above at the same time by running:
-
 ```sh
+make deps # download linting dependencies
+
 make lint
 
 make lint-go # only lint Go code

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ files in place.
 ```sh
 make lint-fix
 
-#make lint-fix-go # Go linter does not support fixes
+make lint-fix-go # only lint and fix Go files
 make lint-fix-md # only lint and fix Markdown files
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,4 @@
 {
-  "scripts": {
-    "lint": "\"$npm_execpath\" run lint-md && \"$npm_execpath\" run lint-go",
-    "lint-fix": "\"$npm_execpath\" run lint-md-fix",
-    "lint-md": "remark . .github",
-    "lint-md-fix": "remark . .github -o",
-    "lint-go": "revive -formatter stylish -config revive.toml ./..."
-  },
   "devDependencies": {
     "remark-cli": "^9.0.0",
     "remark-lint": "^8.0.0",


### PR DESCRIPTION
## Summary

- Added targets to `Makefile` for linting and other utilities like cleaning
- Removed linting from NPM scripts in `package.json`
- Simplified linting docs

## Motivation

Moves focus from relying on NPM for all linting stuff over to Makefile.

Based on https://github.com/iver-wharf/wharf-cmd/pull/31
