### PR TITLE
Changed quotation marks to “”

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Changed `env.Bind` to use generic constraints for compile-time assertions
   instead of runtime assertions. (#40)
 
+- Changed quotation marks in `pkg/logger/consolepretty` to `“”` instead of
+  backtick `` ` `` to result in fewer backslash escapes. (#43)
+
 ## v1.3.0 (2021-11-30)
 
 - Added `Event.WithFunc(func(Event) Event) Event` to `wharf-core/pkg/logger` to

--- a/pkg/logger/consolepretty/pretty.go
+++ b/pkg/logger/consolepretty/pretty.go
@@ -387,7 +387,7 @@ func getPrintableStringRepresentation(value any) (str string, hasValue bool) {
 	switch v := value.(type) {
 	case string:
 		if v == "" {
-			return "``", false
+			return "“”", false
 		}
 		return escapeString(v), true
 	default:
@@ -403,13 +403,11 @@ var escapeStringReplacer = strings.NewReplacer(
 	"\r", `\r`,
 	"\t", `\t`,
 	"\v", `\v`,
-	`\`, `\\`,
-	"`", "\\`",
 )
 
 func escapeString(value string) string {
-	if strings.ContainsAny(value, " \a\b\f\n\r\t\v\"\\`") {
-		return fmt.Sprintf("`%s`", escapeStringReplacer.Replace(value))
+	if strings.ContainsAny(value, " \a\b\f\n\r\t\v") {
+		return fmt.Sprintf("“%s”", escapeStringReplacer.Replace(value))
 	}
 	return value
 }


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed consolepretty to use `“”` as quotation marks instead of backtick `` ` ``

## Motivation

Some values use backticks and then the logs get pretty unreadable with a lot of escaping. This changes it to use other quotation symbols instead.
