### PR TITLE
Fixed ellipsis length bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Changed `env.Bind` to use generic constraints for compile-time assertions
   instead of runtime assertions. (#40)
 
+- Fixed shortened caller file name and scope being miscalculated due to the
+  default ellipsis being 1 rune long but 3 bytes. It will not correctly treat
+  `…` as only 1 rune when calculating the string shortening. (#44)
+
 ## v1.3.0 (2021-11-30)
 
 - Added `Event.WithFunc(func(Event) Event) Event` to `wharf-core/pkg/logger` to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   instead of runtime assertions. (#40)
 
 - Fixed shortened caller file name and scope being miscalculated due to the
-  default ellipsis being 1 rune long but 3 bytes. It will not correctly treat
+  default ellipsis being 1 rune long but 3 bytes. It will now correctly treat
   `…` as only 1 rune when calculating the string shortening. (#44)
 
 ## v1.3.0 (2021-11-30)

--- a/pkg/logger/consolepretty/pretty.go
+++ b/pkg/logger/consolepretty/pretty.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/fatih/color"
 	"github.com/iver-wharf/wharf-core/v2/pkg/logger"
@@ -262,29 +263,35 @@ func New(conf Config) logger.Sink {
 	if conf.Ellipsis == "" {
 		conf.Ellipsis = DefaultConfig.Ellipsis
 	}
-	return sink{&conf}
+	return sink{
+		config:      &conf,
+		ellipsisLen: utf8.RuneCountInString(conf.Ellipsis),
+	}
 }
 
 type sink struct {
-	config *Config
+	config      *Config
+	ellipsisLen int
 }
 
 // NewContext creates a new pretty-console logging Context using the
 // same configuration as the one given when creating the Sink.
 func (s sink) NewContext(scope string) logger.Context {
 	return context{
-		Config: s.config,
-		scope:  scope,
+		Config:      s.config,
+		scope:       scope,
+		ellipsisLen: s.ellipsisLen,
 	}
 }
 
 type context struct {
 	*Config
-	fields     []fieldPair
-	scope      string
-	callerFile string
-	callerLine int
-	err        error
+	fields      []fieldPair
+	scope       string
+	callerFile  string
+	callerLine  int
+	err         error
+	ellipsisLen int
 }
 
 type fieldPair struct {
@@ -485,7 +492,7 @@ func (c context) writeTrimmedRight(w io.Writer, col *color.Color, value string, 
 	if written, ok := c.writeUntrimmedString(w, col, value, maxLen); ok {
 		return written
 	}
-	sliceLen := maxLen - len(c.Ellipsis)
+	sliceLen := maxLen - c.ellipsisLen
 	col.Fprint(w, value[:sliceLen], c.Ellipsis)
 	return maxLen
 }
@@ -494,7 +501,7 @@ func (c context) writeTrimmedLeft(w io.Writer, col *color.Color, value string, m
 	if written, ok := c.writeUntrimmedString(w, col, value, maxLen); ok {
 		return written
 	}
-	sliceStartIndex := len(value) - maxLen + len(c.Ellipsis)
+	sliceStartIndex := len(value) - maxLen + c.ellipsisLen
 	col.Fprint(w, c.Ellipsis, value[sliceStartIndex:])
 	return maxLen
 }
@@ -508,13 +515,9 @@ func (c context) writeUntrimmedString(w io.Writer, col *color.Color, value strin
 	case valueLen == 0 || maxLen <= 0:
 		// do nothing
 		return 0, true
-	case maxLen <= len(c.Ellipsis) && valueLen > len(c.Ellipsis):
-		maxEllipsisLen := len(c.Ellipsis)
-		if maxEllipsisLen > maxLen {
-			maxEllipsisLen = maxLen
-		}
-		col.Fprint(w, c.Ellipsis[:maxEllipsisLen])
-		return maxEllipsisLen, true
+	case maxLen <= c.ellipsisLen && valueLen > c.ellipsisLen:
+		col.Fprint(w, c.Ellipsis)
+		return c.ellipsisLen, true
 	default:
 		col.Fprint(w, value)
 		return valueLen, true

--- a/pkg/logger/consolepretty/pretty_example_test.go
+++ b/pkg/logger/consolepretty/pretty_example_test.go
@@ -54,5 +54,5 @@ func ExampleConfig_Ellipsis() {
 	logger.New().Debug().Message("Sample message.")
 
 	// Output:
-	// [DEBUG|…mple_test.go] Sample message.
+	// [DEBUG|…xample_test.go] Sample message.
 }


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Fixed so ellipsis length is calculated via `utf8.RuneCountInString()` instead of `len()`

## Motivation

Default ellipsis is 1 rune long, but 3 bytes long: `…`

This messed up the "ellipsis width" and shortening/trimming calculations.

Not using `utf8.RuneCountInString()` on the strings themselves as I deem it unnessesary right now. Could patch it as well later, but the values it's shortening is path names, which very rarely has special characters.

Closes #38
