### PR TITLE
Fixed scope logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   default ellipsis being 1 rune long but 3 bytes. It will now correctly treat
   `…` as only 1 rune when calculating the string shortening. (#44)
 
+- Fixed scopes delimiter being written by `pkg/logger/consolepretty` when no
+  scopes are used. (#45)
+
+- Added `Config.DisableScope` in `pkg/logger/consolepretty`. (#45)
+
 ## v1.3.0 (2021-11-30)
 
 - Added `Event.WithFunc(func(Event) Event) Event` to `wharf-core/pkg/logger` to

--- a/pkg/logger/consolepretty/pretty_test.go
+++ b/pkg/logger/consolepretty/pretty_test.go
@@ -1,10 +1,13 @@
 package consolepretty
 
 import (
+	"bytes"
 	"fmt"
 	"math"
 	"testing"
 
+	"github.com/fatih/color"
+	"github.com/iver-wharf/wharf-core/v2/pkg/logger"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -37,6 +40,65 @@ func TestPrintedIntLen(t *testing.T) {
 			assert.Equal(t, tc.want, printedIntLenFast(tc.input), "printedIntLenFast")
 		})
 	}
+}
+
+func TestContextWriteScope(t *testing.T) {
+	tests := []struct {
+		name    string
+		scope   string
+		config  Config
+		longest int
+		want    string
+	}{
+		{
+			name:    "no scope",
+			scope:   "",
+			longest: 0,
+			want:    "",
+		},
+		{
+			name:    "with scope",
+			scope:   "abc",
+			longest: 0,
+			want:    "|abc",
+		},
+		{
+			name:    "padded",
+			scope:   "abc",
+			config:  Config{ScopeMinLength: 6},
+			longest: 0,
+			want:    "|abc   ",
+		},
+		{
+			name:    "autopadded",
+			scope:   "abc",
+			config:  Config{ScopeMinLengthAuto: true},
+			longest: 6,
+			want:    "|abc   ",
+		},
+		{
+			name:    "maxxed",
+			scope:   "abcdef",
+			config:  Config{ScopeMaxLength: 3},
+			longest: 0,
+			want:    "|abc",
+		},
+	}
+	color.NoColor = true
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			logger.LongestScopeNameLength = tc.longest
+			tc.config.Coloring = &DefaultColorConfig
+			ctx := context{
+				scope:  tc.scope,
+				Config: &tc.config,
+			}
+			var buf bytes.Buffer
+			ctx.writeScope(&buf)
+			assert.Equal(t, tc.want, buf.String())
+		})
+	}
+	logger.LongestScopeNameLength = 0
 }
 
 var varThatDisablesCompilerOptimizations int


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Fixed so scopes doesn't log weirdly
- Refactored a little

## Motivation

Closes #36
