### PR TITLE
Reroute problems to wharf.iver.com

### DIFF
--- a/pkg/ginutil/writeproblem.go
+++ b/pkg/ginutil/writeproblem.go
@@ -14,7 +14,7 @@ import (
 //
 // Problem.Type is set to "about:blank" (as recommended by the IETF RFC-7808)
 // if left unset, or converts scheme-less URIs to start with
-// "https://iver-wharf.github.io/#/".
+// "https://wharf.iver.com/#/".
 //
 // Problem.Status is set to 500 (Internal Server Error) if left unset.
 //

--- a/pkg/ginutil/writeproblem_example_test.go
+++ b/pkg/ginutil/writeproblem_example_test.go
@@ -26,7 +26,7 @@ func indentedBodyFromResponse(resp *http.Response) string {
 
 func ExampleWriteProblem() {
 	var prob = problem.Response{
-		Type:     "https://iver-wharf.github.io/#/prob/build/run/invalid-input",
+		Type:     "https://wharf.iver.com/#/prob/build/run/invalid-input",
 		Title:    "Invalid input variable for build.",
 		Status:   400,
 		Detail:   "Build requires input variable 'myInput' to be of type 'string', but got 'int' instead.",
@@ -53,7 +53,7 @@ func ExampleWriteProblem() {
 	// Content-Type: application/problem+json
 	//
 	// {
-	//   "type": "https://iver-wharf.github.io/#/prob/build/run/invalid-input",
+	//   "type": "https://wharf.iver.com/#/prob/build/run/invalid-input",
 	//   "title": "Invalid input variable for build.",
 	//   "status": 400,
 	//   "detail": "Build requires input variable 'myInput' to be of type 'string', but got 'int' instead.",

--- a/pkg/problem/docsurl.go
+++ b/pkg/problem/docsurl.go
@@ -4,7 +4,7 @@ import "net/url"
 
 // DocsHost is the host name of the documentation page. Use in various helper
 // functions as a fallback if no host is provided.
-var DocsHost = "iver-wharf.github.io"
+var DocsHost = "wharf.iver.com"
 
 // ConvertURLToAbsDocsURL adds schema and sets the host if that has not been set.
 func ConvertURLToAbsDocsURL(u url.URL) *url.URL {

--- a/pkg/problem/docsurl_example_test.go
+++ b/pkg/problem/docsurl_example_test.go
@@ -8,13 +8,13 @@ import (
 func ExampleConvertURLToAbsDocsURL() {
 	var u *url.URL
 
-	u, _ = url.Parse("https://iver-wharf.github.io/#/prob/build/run/invalid-input")
+	u, _ = url.Parse("https://wharf.iver.com/#/prob/build/run/invalid-input")
 	fmt.Println("Unaltered 1:", ConvertURLToAbsDocsURL(*u).String() == u.String())
 
 	u, _ = url.Parse("http://some-other-page/prob/build/run/invalid-input")
 	fmt.Println("Unaltered 2:", ConvertURLToAbsDocsURL(*u).String() == u.String())
 
-	u, _ = url.Parse("https://iver-wharf.github.io/prob/build/run/invalid-input")
+	u, _ = url.Parse("https://wharf.iver.com/prob/build/run/invalid-input")
 	fmt.Println("Fragmented path:", ConvertURLToAbsDocsURL(*u).String())
 
 	u, _ = url.Parse("/prob/build/run/invalid-input")
@@ -26,7 +26,7 @@ func ExampleConvertURLToAbsDocsURL() {
 	// Output:
 	// Unaltered 1: true
 	// Unaltered 2: true
-	// Fragmented path: https://iver-wharf.github.io/#/prob/build/run/invalid-input
-	// Added schema & host: https://iver-wharf.github.io/#/prob/build/run/invalid-input
+	// Fragmented path: https://wharf.iver.com/#/prob/build/run/invalid-input
+	// Added schema & host: https://wharf.iver.com/#/prob/build/run/invalid-input
 	// Leaves original intact: true
 }

--- a/pkg/problem/response.go
+++ b/pkg/problem/response.go
@@ -26,7 +26,7 @@ type Response struct {
 	// human-readable documentation for the problem type (e.g., using HTML).
 	// When this member is not present, its value is assumed to be
 	// "about:blank".
-	Type string `json:"type" example:"https://iver-wharf.github.io/#/prob/build/run/invalid-input"`
+	Type string `json:"type" example:"https://wharf.iver.com/#/prob/build/run/invalid-input"`
 
 	// Title is a short, human-readable summary of the problem type.
 	// It SHOULD NOT change from occurrence to ocurrence of the problem, except

--- a/pkg/problem/response_example_test.go
+++ b/pkg/problem/response_example_test.go
@@ -17,7 +17,7 @@ func ExampleParseHTTPResponse() {
 	req.Response = &http.Response{
 		Body: io.NopCloser(strings.NewReader(`
 {
-  "type": "https://iver-wharf.github.io/#/prob/build/run/invalid-input",
+  "type": "https://wharf.iver.com/#/prob/build/run/invalid-input",
   "title": "Invalid input variable for build.",
   "status": 400,
   "detail": "Build requires input variable 'myInput' to be of type 'string', but got 'int' instead.",
@@ -41,7 +41,7 @@ func ExampleParseHTTPResponse() {
 	}
 
 	// Output:
-	// {(problem) HTTP 400, https://iver-wharf.github.io/#/prob/build/run/invalid-input
+	// {(problem) HTTP 400, https://wharf.iver.com/#/prob/build/run/invalid-input
 	//     Title: Invalid input variable for build.
 	//    Detail: Build requires input variable 'myInput' to be of type 'string', but got 'int' instead.
 	//  Error(s): [strconv.ParseUint: parsing "-1": invalid syntax]


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed to route problems to `wharf.iver.com` by default instead

## Motivation

We now have wharf.iver.com pointing towards our GitHub Pages instead.
