### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v2.0.0 (WIP)
+## v2.0.0 (2022-05-20)
 
 - BREAKING: Changed minor version of Go from 1.16 to 1.18. (#40)
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 Utility Go code used by numerous other Wharf components.
 
+```sh
+go get -u github.com/iver-wharf/wharf-core/v2
+```
+
 Mantra of this repository is to include code that will be used in more than 1
 other repository, and does not solve any particular use case. It's more for
 common code. It holds code that does not solve any particular problems that’s


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR

## Changes

- BREAKING: Changed minor version of Go from 1.16 to 1.18. (#40)

- BREAKING: Changed module path from `github.com/iver-wharf/wharf-core` to `github.com/iver-wharf/wharf-core/v2`. (#40)

- Changed `env.Bind` to use generic constraints for compile-time assertions instead of runtime assertions. (#40)

- Changed quotation marks in `pkg/logger/consolepretty` to `“”` instead of backtick `` ` `` to result in fewer backslash escapes. (#43)

- Fixed shortened caller file name and scope being miscalculated due to the default ellipsis being 1 rune long but 3 bytes. It will now correctly treat `…` as only 1 rune when calculating the string shortening. (#44)

- Fixed scopes delimiter being written by `pkg/logger/consolepretty` when no scopes are used. (#45)

- Added `Config.DisableScope` in `pkg/logger/consolepretty`. (#45)

- Changed version of dependencies:

  - `github.com/fatih/color` from v1.12.0 to v1.13.0 (#46)
  - `github.com/gin-gonic/gin` from v1.7.1 to v1.7.7 (#46)
  - `github.com/mattn/go-colorable` from v0.1.8 to v0.1.12 (#46)
  - `github.com/spf13/viper` from v1.7.1 to v1.10.1 (#46)
  - `github.com/stretchr/testify` from v1.7.0 to v1.7.1 (#46)
  - `gorm.io/driver/postgres` from v1.1.0 to v1.3.1 (#46)
  - `gorm.io/gorm` from v1.21.11 to v1.23.3 (#46)

- Changed `DocsHome` in `pkg/problem` to `wharf.iver.com`. (#48)

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
